### PR TITLE
feat: scaffold hyperlane-midnight crate and wire into framework

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -5889,6 +5889,7 @@ dependencies = [
  "hyperlane-ethereum",
  "hyperlane-fuel",
  "hyperlane-metric",
+ "hyperlane-midnight",
  "hyperlane-operation-verifier",
  "hyperlane-radix",
  "hyperlane-sealevel",
@@ -6118,6 +6119,16 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "url",
+]
+
+[[package]]
+name = "hyperlane-midnight"
+version = "2.2.0"
+dependencies = [
+ "hyperlane-core",
+ "thiserror 1.0.63",
+ "tokio",
  "url",
 ]
 

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "chains/hyperlane-cosmos",
   "chains/hyperlane-ethereum",
   "chains/hyperlane-fuel",
+  "chains/hyperlane-midnight",
   "chains/hyperlane-radix",
   "chains/hyperlane-sealevel",
   "chains/hyperlane-tron",

--- a/rust/main/agents/validator/src/reorg_reporter.rs
+++ b/rust/main/agents/validator/src/reorg_reporter.rs
@@ -151,7 +151,7 @@ impl LatestCheckpointReorgReporter {
         #[cfg(feature = "aleo")]
         use ChainConnectionConf::Aleo;
         use ChainConnectionConf::{
-            Cosmos, CosmosNative, Ethereum, Fuel, Radix, Sealevel, Starknet, Tron,
+            Cosmos, CosmosNative, Ethereum, Fuel, Midnight, Radix, Sealevel, Starknet, Tron,
         };
 
         let chain_conf = settings
@@ -214,6 +214,15 @@ impl LatestCheckpointReorgReporter {
                     Tron(updated_conn)
                 })
             }
+            Midnight(conn) => Self::map_urls_to_connections(
+                vec![conn.indexer_graphql_url.clone()],
+                conn,
+                |conn, url| {
+                    let mut updated_conn = conn.clone();
+                    updated_conn.indexer_graphql_url = url;
+                    Midnight(updated_conn)
+                },
+            ),
         };
 
         chain_conn_confs

--- a/rust/main/chains/hyperlane-midnight/Cargo.toml
+++ b/rust/main/chains/hyperlane-midnight/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hyperlane-midnight"
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
+
+thiserror = { workspace = true }
+# `macros` is required for feature unification: hyperlane-core's
+# `rpc_clients::fallback::test` module (unconditionally `pub`) uses
+# `#[tokio::test]` but its own tokio dep omits `macros`. When the
+# workspace is built, other crates pull `macros` in transitively;
+# when running `cargo test -p hyperlane-midnight` standalone the
+# graph is too thin and `hyperlane-core` fails to compile without this.
+tokio = { workspace = true, features = ["macros"] }
+url = { workspace = true }

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -1,0 +1,26 @@
+use url::Url;
+
+/// Midnight connection configuration.
+///
+/// Contract addresses flow via the standard `CoreContractAddresses` struct
+/// at the `ChainConf` level, not this struct. Native token metadata flows via
+/// `ChainConf.native_token`.
+#[derive(Clone, Debug)]
+pub struct ConnectionConf {
+    /// GraphQL URL for the Midnight indexer (primary data source for reads).
+    pub indexer_graphql_url: Url,
+    /// Filesystem path to the `midnight-node-toolkit` binary used by the
+    /// Classic `Mailbox::process` implementation (issue #20). Optional at
+    /// scaffolding time (#13).
+    pub toolkit_path: Option<String>,
+}
+
+impl ConnectionConf {
+    /// Construct a new `ConnectionConf`.
+    pub fn new(indexer_graphql_url: Url, toolkit_path: Option<String>) -> Self {
+        Self {
+            indexer_graphql_url,
+            toolkit_path,
+        }
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/error.rs
+++ b/rust/main/chains/hyperlane-midnight/src/error.rs
@@ -1,0 +1,18 @@
+use hyperlane_core::ChainCommunicationError;
+
+/// Errors produced by the `hyperlane-midnight` crate.
+#[derive(Debug, thiserror::Error)]
+pub enum HyperlaneMidnightError {
+    /// Feature not implemented yet — replaced in issues #14–#20.
+    #[error("Midnight: {0} not implemented yet")]
+    NotImplemented(&'static str),
+    /// Other errors.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<HyperlaneMidnightError> for ChainCommunicationError {
+    fn from(value: HyperlaneMidnightError) -> Self {
+        ChainCommunicationError::from_other(value)
+    }
+}

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -1,0 +1,17 @@
+//! Scaffolding for the Midnight chain integration.
+//!
+//! Issue #13 (T16): framework wiring only. Real trait impls (Mailbox, indexers,
+//! ValidatorAnnounce, provider) land in issues #14–#20. Transaction submission
+//! uses the Classic submitter path, shelling out to `midnight-node-toolkit`
+//! (see issue #20).
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod config;
+mod error;
+mod signer;
+
+pub use config::ConnectionConf;
+pub use error::HyperlaneMidnightError;
+pub use signer::MidnightSigner;

--- a/rust/main/chains/hyperlane-midnight/src/signer.rs
+++ b/rust/main/chains/hyperlane-midnight/src/signer.rs
@@ -1,0 +1,59 @@
+use hyperlane_core::H256;
+
+/// Placeholder signer for Midnight.
+///
+/// Real signing is performed by the `midnight-node-toolkit` subprocess
+/// (issue #20). This struct exists at scaffolding time only to satisfy the
+/// `ChainSigner` + `BuildableWithSignerConf` trait surface in
+/// `hyperlane-base`.
+#[derive(Clone, Debug, Default)]
+pub struct MidnightSigner {
+    address: String,
+    address_h256: H256,
+}
+
+impl MidnightSigner {
+    /// Construct a placeholder signer. At #13 the address is empty / zero;
+    /// #20 will populate these from the toolkit.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the configured address (empty at #13).
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Returns the configured address as `H256` (zero at #13).
+    pub fn address_h256(&self) -> H256 {
+        self.address_h256
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    use crate::ConnectionConf;
+
+    #[test]
+    fn config_constructs() {
+        let conf = ConnectionConf::new(
+            Url::parse("http://localhost:8080/graphql").unwrap(),
+            Some("/usr/local/bin/midnight-node-toolkit".to_string()),
+        );
+        assert_eq!(
+            conf.indexer_graphql_url.as_str(),
+            "http://localhost:8080/graphql"
+        );
+        assert!(conf.toolkit_path.is_some());
+    }
+
+    #[test]
+    fn signer_constructs() {
+        let signer = MidnightSigner::new();
+        assert_eq!(signer.address(), "");
+        assert_eq!(signer.address_h256(), H256::zero());
+    }
+}

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -62,6 +62,7 @@ hyperlane-test = { path = "../hyperlane-test" }
 hyperlane-aleo = { path = "../chains/hyperlane-aleo", optional = true }
 hyperlane-ethereum = { path = "../chains/hyperlane-ethereum" }
 hyperlane-fuel = { path = "../chains/hyperlane-fuel" }
+hyperlane-midnight = { path = "../chains/hyperlane-midnight" }
 hyperlane-cosmos = { path = "../chains/hyperlane-cosmos" }
 hyperlane-starknet = { path = "../chains/hyperlane-starknet" }
 hyperlane-sealevel = { path = "../chains/hyperlane-sealevel" }

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
@@ -47,6 +47,7 @@ impl Indexable for HyperlaneMessage {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::SequenceAware,
+            HyperlaneDomainProtocol::Midnight => CursorType::SequenceAware,
         }
     }
 
@@ -72,6 +73,7 @@ impl Indexable for InterchainGasPayment {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::RateLimited,
+            HyperlaneDomainProtocol::Midnight => CursorType::SequenceAware,
         }
     }
 
@@ -92,6 +94,7 @@ impl Indexable for MerkleTreeInsertion {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::SequenceAware,
+            HyperlaneDomainProtocol::Midnight => CursorType::SequenceAware,
         }
     }
 
@@ -112,6 +115,7 @@ impl Indexable for Delivery {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::RateLimited,
+            HyperlaneDomainProtocol::Midnight => CursorType::SequenceAware,
         }
     }
 

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -29,6 +29,7 @@ use hyperlane_ethereum::{
     EthereumReorgPeriod, EthereumValidatorAnnounceAbi,
 };
 use hyperlane_fuel as h_fuel;
+use hyperlane_midnight::{self as h_midnight, MidnightSigner};
 use hyperlane_radix::{self as h_radix, RadixProvider};
 use hyperlane_sealevel::{
     self as h_sealevel, fallback::SealevelFallbackRpcClient, SealevelProvider, TransactionSubmitter,
@@ -191,6 +192,8 @@ pub enum ChainConnectionConf {
     Aleo(h_aleo::ConnectionConf),
     /// Tron configuration
     Tron(h_tron::ConnectionConf),
+    /// Midnight configuration
+    Midnight(h_midnight::ConnectionConf),
 }
 
 impl ChainConnectionConf {
@@ -207,6 +210,7 @@ impl ChainConnectionConf {
             Self::Tron(_) => HyperlaneDomainProtocol::Tron,
             #[cfg(feature = "aleo")]
             Self::Aleo(_) => HyperlaneDomainProtocol::Aleo,
+            Self::Midnight(_) => HyperlaneDomainProtocol::Midnight,
         }
     }
 
@@ -298,6 +302,9 @@ impl ChainConf {
                 h_aleo::application::AleoApplicationOperationVerifier::new(),
             )
                 as Box<dyn ApplicationOperationVerifier>),
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: application operation verifier is not yet implemented (see issues #14-#20)"
+            )),
         };
 
         result.context(ctx)
@@ -354,6 +361,9 @@ impl ChainConf {
                 let provider = build_aleo_provider(self, conf, metrics, &locator, None)?;
                 Ok(Box::new(provider) as Box<dyn HyperlaneProvider>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: HyperlaneProvider is not yet implemented (see issues #14-#20)"
+            )),
         }
         .context(ctx)
     }
@@ -435,6 +445,9 @@ impl ChainConf {
                 let mailbox = h_aleo::AleoMailbox::new(provider, &locator, conf);
                 Ok(Box::new(mailbox) as Box<dyn Mailbox>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: Mailbox is not yet implemented (see issue #20)"
+            )),
         }
         .context(ctx)
     }
@@ -503,6 +516,9 @@ impl ChainConf {
 
                 Ok(Box::new(hook) as Box<dyn MerkleTreeHook>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: MerkleTreeHook is not yet implemented (see issue #15)"
+            )),
         }
         .context(ctx)
     }
@@ -592,6 +608,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<HyperlaneMessage>>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: message dispatch indexer is not yet implemented (see issue #16)"
+            )),
         }
         .context(ctx)
     }
@@ -677,6 +696,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<H256>>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: delivery indexer is not yet implemented (see issue #16)"
+            )),
         }
         .context(ctx)
     }
@@ -754,6 +776,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn InterchainGasPaymaster>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: InterchainGasPaymaster is not yet implemented (see issue #19)"
+            )),
         }
         .context(ctx)
     }
@@ -834,6 +859,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<InterchainGasPayment>>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: interchain gas payment indexer is not yet implemented (see issue #19)"
+            )),
         }
         .context(ctx)
     }
@@ -922,6 +950,9 @@ impl ChainConf {
 
                 Ok(Box::new(indexer) as Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: merkle tree hook indexer is not yet implemented (see issue #15)"
+            )),
         }
         .context(ctx)
     }
@@ -1010,6 +1041,9 @@ impl ChainConf {
                     h_aleo::AleoValidatorAnnounce::new(provider, &locator, conf);
                 Ok(Box::new(validator_announce) as Box<dyn ValidatorAnnounce>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: ValidatorAnnounce is not yet implemented (see issue #33)"
+            )),
         }
         .context("Building ValidatorAnnounce")
     }
@@ -1084,6 +1118,9 @@ impl ChainConf {
                 let ism = h_aleo::AleoIsm::new(provider, &locator, conf)?;
                 Ok(Box::new(ism) as Box<dyn InterchainSecurityModule>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: InterchainSecurityModule is not yet implemented (see issue #14)"
+            )),
         }
         .context(ctx)
     }
@@ -1149,6 +1186,9 @@ impl ChainConf {
                 let ism = h_aleo::AleoIsm::new(provider, &locator, conf)?;
                 Ok(Box::new(ism) as Box<dyn MultisigIsm>)
             }
+            ChainConnectionConf::Midnight(_) => Err(eyre!(
+                "Midnight: MultisigIsm is not yet implemented (see issue #14)"
+            )),
         }
         .context(ctx)
     }
@@ -1209,6 +1249,9 @@ impl ChainConf {
                 let ism = h_aleo::AleoIsm::new(provider, &locator, conf)?;
                 Ok(Box::new(ism) as Box<dyn RoutingIsm>)
             }
+            ChainConnectionConf::Midnight(_) => {
+                Err(eyre!("Midnight does not support routing ISM")).context(ctx)
+            }
         }
         .context(ctx)
     }
@@ -1265,6 +1308,9 @@ impl ChainConf {
             }
             #[cfg(feature = "aleo")]
             ChainConnectionConf::Aleo(_) => Err(eyre!("Aleo support missing")).context(ctx),
+            ChainConnectionConf::Midnight(_) => {
+                Err(eyre!("Midnight does not support aggregation ISM")).context(ctx)
+            }
         }
         .context(ctx)
     }
@@ -1307,6 +1353,9 @@ impl ChainConf {
             }
             #[cfg(feature = "aleo")]
             ChainConnectionConf::Aleo(_) => Err(eyre!("Aleo support missing")).context(ctx),
+            ChainConnectionConf::Midnight(_) => {
+                Err(eyre!("Midnight does not support CCIP read ISM")).context(ctx)
+            }
         }
         .context(ctx)
     }
@@ -1343,6 +1392,7 @@ impl ChainConf {
                 ChainConnectionConf::Tron(_) => Box::new(conf.build::<h_tron::TronSigner>().await?),
                 #[cfg(feature = "aleo")]
                 ChainConnectionConf::Aleo(_) => Box::new(conf.build::<h_aleo::AleoSigner>().await?),
+                ChainConnectionConf::Midnight(_) => Box::new(conf.build::<MidnightSigner>().await?),
             };
             Ok(Some(chain_signer))
         } else {
@@ -1383,6 +1433,11 @@ impl ChainConf {
     }
 
     async fn tron_signer(&self) -> Result<Option<h_tron::TronSigner>> {
+        self.signer().await
+    }
+
+    #[allow(dead_code)]
+    async fn midnight_signer(&self) -> Result<Option<MidnightSigner>> {
         self.signer().await
     }
 

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -777,6 +777,37 @@ pub fn build_aleo_connection_conf(
     }
 }
 
+pub fn build_midnight_connection_conf(
+    _rpcs: &[Url],
+    chain: &ValueParser,
+    err: &mut ConfigParsingError,
+    _operation_batch: OpSubmissionConfig,
+) -> Option<ChainConnectionConf> {
+    let mut local_err = ConfigParsingError::default();
+
+    let indexer_graphql_url: Option<Url> = chain
+        .chain(&mut local_err)
+        .get_key("indexerGraphqlUrl")
+        .parse_from_str("Invalid Midnight indexer GraphQL URL")
+        .end();
+
+    let toolkit_path: Option<String> = chain
+        .chain(&mut local_err)
+        .get_opt_key("toolkitPath")
+        .parse_string()
+        .end()
+        .map(|s| s.to_string());
+
+    if !local_err.is_ok() {
+        err.merge(local_err);
+        None
+    } else {
+        Some(ChainConnectionConf::Midnight(
+            hyperlane_midnight::ConnectionConf::new(indexer_graphql_url?, toolkit_path),
+        ))
+    }
+}
+
 pub fn build_connection_conf(
     domain_protocol: HyperlaneDomainProtocol,
     rpcs: &[Url],
@@ -817,6 +848,9 @@ pub fn build_connection_conf(
         HyperlaneDomainProtocol::Aleo => {
             build_aleo_connection_conf(rpcs, chain, err, operation_batch)
         }
+        HyperlaneDomainProtocol::Midnight => {
+            build_midnight_connection_conf(rpcs, chain, err, operation_batch)
+        }
         #[allow(unreachable_patterns)]
         _ => unreachable!("Unsupported protocol chains are pre-filtered"),
     }
@@ -827,7 +861,9 @@ pub fn build_connection_conf(
 pub fn is_protocol_supported(protocol: HyperlaneDomainProtocol) -> bool {
     use HyperlaneDomainProtocol::*;
     match protocol {
-        Ethereum | Fuel | Sealevel | Cosmos | CosmosNative | Starknet | Radix | Tron => true,
+        Ethereum | Fuel | Sealevel | Cosmos | CosmosNative | Starknet | Radix | Tron | Midnight => {
+            true
+        }
         // Aleo is feature-gated - only supported when the "aleo" feature is enabled
         Aleo => cfg!(feature = "aleo"),
     }

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -319,6 +319,29 @@ impl ChainSigner for hyperlane_aleo::AleoSigner {
     }
 }
 
+#[async_trait]
+impl BuildableWithSignerConf for hyperlane_midnight::MidnightSigner {
+    async fn build(conf: &SignerConf) -> Result<Self, Report> {
+        match conf {
+            SignerConf::Node => Ok(hyperlane_midnight::MidnightSigner::new()),
+            _ => bail!(format!(
+                "{conf:?} is not supported by midnight; use signer type `node` \
+                 (transaction signing is delegated to `midnight-node-toolkit` in issue #20)"
+            )),
+        }
+    }
+}
+
+impl ChainSigner for hyperlane_midnight::MidnightSigner {
+    fn address_string(&self) -> String {
+        self.address().to_owned()
+    }
+
+    fn address_h256(&self) -> H256 {
+        self.address_h256()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ethers::{signers::LocalWallet, utils::hex};

--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -195,6 +195,7 @@ pub enum KnownHyperlaneDomain {
     Merlin = 4200,
     Metal = 1000001750,
     Metis = 1088,
+    Midnight = 1234,
     MiracleChain = 92278,
     Milkyway = 1835625579,
     Mode = 34443,
@@ -371,6 +372,8 @@ pub enum HyperlaneDomainProtocol {
     Aleo,
     /// Tron chain
     Tron,
+    /// Midnight chain
+    Midnight,
 }
 
 impl HyperlaneDomainProtocol {
@@ -436,7 +439,9 @@ impl KnownHyperlaneDomain {
             | StarknetSepolia => HyperlaneDomainType::Testnet,
             Test1 | Test2 | Test3 | Test4 | FuelTest1 | SealevelTest1 | SealevelTest2
             | CosmosTest99990 | CosmosTest99991 | CosmosTestNative1 | CosmosTestNative2
-            | StarknetTest23448593 | StarknetTest23448594 => HyperlaneDomainType::LocalTestChain,
+            | Midnight | StarknetTest23448593 | StarknetTest23448594 => {
+                HyperlaneDomainType::LocalTestChain
+            }
             _ => HyperlaneDomainType::Mainnet,
         }
     }
@@ -476,6 +481,7 @@ impl KnownHyperlaneDomain {
             | ParadexSepolia => HyperlaneDomainProtocol::Starknet,
             Radix | RadixTestnet => HyperlaneDomainProtocol::Radix,
             Aleo | AleoTestnet => HyperlaneDomainProtocol::Aleo,
+            Midnight => HyperlaneDomainProtocol::Midnight,
             _ => HyperlaneDomainProtocol::Ethereum
         }
     }
@@ -694,7 +700,7 @@ impl HyperlaneDomain {
         let protocol = self.domain_protocol();
         match protocol {
             Ethereum | Cosmos | CosmosNative | Starknet | Tron => IndexMode::Block,
-            Fuel | Sealevel | Radix | Aleo => IndexMode::Sequence,
+            Fuel | Sealevel | Radix | Aleo | Midnight => IndexMode::Sequence,
         }
     }
 }

--- a/rust/main/hyperlane-core/src/metrics/agent.rs
+++ b/rust/main/hyperlane-core/src/metrics/agent.rs
@@ -8,6 +8,7 @@ const ETHEREUM_DECIMALS: u8 = 18;
 const COSMOS_DECIMALS: u8 = 6;
 const SOLANA_DECIMALS: u8 = 9;
 const ALEO_DECIMALS: u8 = 6;
+const NIGHT_DECIMALS: u8 = 6;
 
 /// Interval for querying the prometheus metrics endpoint.
 /// This should be whatever the prometheus scrape interval is
@@ -27,6 +28,7 @@ pub fn decimals_by_protocol(protocol: HyperlaneDomainProtocol) -> u8 {
         HyperlaneDomainProtocol::Cosmos | HyperlaneDomainProtocol::CosmosNative => COSMOS_DECIMALS,
         HyperlaneDomainProtocol::Sealevel => SOLANA_DECIMALS,
         HyperlaneDomainProtocol::Aleo => ALEO_DECIMALS,
+        HyperlaneDomainProtocol::Midnight => NIGHT_DECIMALS,
         _ => ETHEREUM_DECIMALS,
     }
 }

--- a/rust/main/lander/src/adapter/chains/factory.rs
+++ b/rust/main/lander/src/adapter/chains/factory.rs
@@ -69,6 +69,12 @@ impl AdapterFactory {
                 let adapter = TronAdapter::from_conf(conf, core_metrics, &connection_conf).await?;
                 Arc::new(adapter)
             }
+            ChainConnectionConf::Midnight(_) => todo!(
+                "Issue #20: Midnight uses the Classic submitter by default. \
+                 This arm is only reached if a chain config explicitly sets `submitter: lander`. \
+                 If Lander support becomes desirable, implement `AdaptsChain` for Midnight here \
+                 (spawning `midnight-node-toolkit` as a subprocess)."
+            ),
         };
         Ok(adapter)
     }


### PR DESCRIPTION
## Summary
- Adds `hyperlane-midnight` crate (`ConnectionConf`, `MidnightSigner`, `HyperlaneMidnightError`) — placeholders; real trait impls land in #14–#20.
- Threads `Midnight` through every protocol-discriminated match site: `HyperlaneDomainProtocol`, `KnownHyperlaneDomain` (= 1234, LocalTestChain), `ChainConnectionConf`, indexer cursors (all SequenceAware), validator reorg reporter, lander factory, signer config, connection parser.
- All 14 `build_*` methods on `ChainConf` get Midnight arms — message/dispatch/IGP/MerkleTreeHook/etc. return deferred-to-#14-#20 errors; routing/aggregation/CCIP-read ISMs are permanently unsupported. Classic submitter by default; Lander factory arm is `todo!()` for explicit opt-in.
- Divergences from the original spec are documented in equilibriumco/hyperlane-midnight#13 (Rust toolkit not TS, Classic over Lander, domain ID, additional match sites).

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo test -p hyperlane-midnight` (2/2)
- [x] `cargo clippy --features aleo,integration_test -- -D warnings`
- [x] `cargo fmt --check`

Closes equilibriumco/hyperlane-midnight#13.