### PR TITLE
fix(#80): dry-run process_estimate_costs so reverting inbound messages back off

### DIFF
--- a/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
+++ b/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
@@ -264,15 +264,60 @@ async fn count_returns_zero_for_destination_only_impl() {
     assert_eq!(mailbox.count(&ReorgPeriod::None).await.unwrap(), 0);
 }
 
+// `process_estimate_costs` now dry-runs `handle` (issue #80). A dry-run that
+// accepts the message returns `{"ok":true}` and the estimate keeps the fixed
+// non-zero placeholder cost (Midnight fees are DUST, computed by the wallet at
+// submit time). The request it sends must be the `dryRunHandle` op — proving
+// the estimate actually simulates rather than blindly succeeding.
 #[tokio::test]
-async fn process_estimate_costs_returns_non_zero_placeholder() {
-    let stub = StubSubmitter::always_returns("{}");
+async fn process_estimate_costs_dry_runs_and_returns_placeholder_on_accept() {
+    let stub = StubSubmitter::always_returns(r#"{"ok":true}"#);
     let mailbox = build_mailbox(&stub);
     let estimate = mailbox
         .process_estimate_costs(&sample_message(), &sample_metadata())
         .await
         .unwrap();
     assert!(!estimate.gas_limit.is_zero());
+
+    let req = stub.captured_request();
+    assert_eq!(req["op"], "dryRunHandle");
+    assert_eq!(req["contractAddress"], format!("{TEST_CONTRACT_ADDRESS:x}"));
+    assert_eq!(req["isContractRecipient"], false);
+    // No transaction is built, so the node/proof endpoints are absent.
+    assert!(req.get("nodeRpcUrl").is_none());
+    assert!(req.get("proofServerUrl").is_none());
+}
+
+// The #80 fix, at the mailbox seam: a dry-run that detects a revert returns
+// `Err`, which `pending_message::prepare` maps to `ErrorEstimatingGas` and then
+// backs off — instead of the revert only surfacing at submit time on the
+// no-backoff path where it would busy-loop and starve other deliveries.
+#[tokio::test]
+async fn process_estimate_costs_errs_when_dry_run_detects_revert() {
+    let stub = StubSubmitter::always_returns(
+        r#"{"error":{"kind":"contractRevert","message":"Routes: sender not enrolled"}}"#,
+    );
+    let mailbox = build_mailbox(&stub);
+    let err = mailbox
+        .process_estimate_costs(&sample_message(), &sample_metadata())
+        .await
+        .unwrap_err();
+    let display = format!("{err}");
+    assert!(display.contains("contractRevert"), "unexpected error: {display}");
+    assert!(display.contains("not enrolled"), "unexpected error: {display}");
+}
+
+// Metadata too short to parse fails before the dry-run, so a structurally
+// broken message also errors (backs off) rather than reaching submit.
+#[tokio::test]
+async fn process_estimate_costs_errs_on_unparseable_metadata() {
+    let stub = StubSubmitter::always_returns(r#"{"ok":true}"#);
+    let mailbox = build_mailbox(&stub);
+    let short = Metadata::new(vec![0u8; 10]);
+    let result = mailbox
+        .process_estimate_costs(&sample_message(), &short)
+        .await;
+    assert!(result.is_err(), "expected a metadata parse error");
 }
 
 #[tokio::test]

--- a/rust/main/chains/hyperlane-midnight/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-midnight/src/mailbox.rs
@@ -179,11 +179,43 @@ impl Mailbox for MidnightMailbox {
 
     async fn process_estimate_costs(
         &self,
-        _message: &HyperlaneMessage,
-        _metadata: &Metadata,
+        message: &HyperlaneMessage,
+        metadata: &Metadata,
     ) -> ChainResult<TxCostEstimate> {
-        // Midnight fees are denominated in DUST and computed by the wallet at
-        // submission time. The relayer just needs a non-zero placeholder here.
+        // Dry-run `handle` against current chain state (no proving, no
+        // submission). A message that would revert (unenrolled sender, amount
+        // over escrow, paused, replay, failed ISM, ...) returns `Err` here, so
+        // the relayer catches it at prepare time and applies the standard
+        // exponential backoff — rather than the revert only surfacing at submit
+        // time on the no-backoff `ErrorSubmitting` path, where it would
+        // busy-loop and starve every other inbound delivery (issue #80). This
+        // mirrors every other Hyperlane chain, whose `process_estimate_costs`
+        // simulates the call.
+        //
+        // Prepare the metadata exactly as `process` does (parse + sort by
+        // validator index + pad) so the dry-run executes what a real
+        // submission would — in particular the on-chain ISM's forward-only
+        // two-pointer walk requires signatures in validator-set order, so an
+        // unsorted vector would spuriously "revert".
+        let mut parsed = parse_metadata(metadata.as_ref())?;
+        let validators = self.validator_order().await?;
+        if !validators.is_empty() {
+            sort_signatures_by_validator_index(message, &mut parsed, &validators)?;
+        }
+        let request = toolkit::build_dry_run_request(
+            self.address,
+            &self.toolkit_ctx,
+            message,
+            parsed,
+            false,
+        );
+        toolkit::dry_run_handle(&self.toolkit_ctx, &request).await?;
+
+        // The message would be accepted on-chain. Midnight fees are denominated
+        // in DUST and computed by the wallet at submission time, so the cost
+        // fields stay a fixed placeholder — unchanged from the previous stub,
+        // which keeps the gas-payment-enforcement policies that read these
+        // fields behaving exactly as before.
         Ok(TxCostEstimate {
             gas_limit: U256::from(1_000_000_u32),
             gas_price: FixedPointNumber::from_str("1")

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -13,6 +13,10 @@ const SUBMIT_TIMEOUT: Duration = Duration::from_secs(120);
 const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
 const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(120);
 const STORAGE_LOCATIONS_TIMEOUT: Duration = Duration::from_secs(60);
+// Dry-run fetches state and executes `handle` locally (keccak/ecrecover
+// witnesses, no proving, no broadcast) — heavier than the `isDelivered`
+// read but far cheaper than a real submission.
+const DRY_RUN_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Maximum byte length of a storage location, matching the on-chain
 /// `Bytes<480>` buffer and the `MAX_STORAGE_LOCATION_LEN` circuit. A location
@@ -80,6 +84,42 @@ pub struct WireMetadata {
     pub index: u32,
     /// Validator signatures, padded to 16 entries.
     pub signatures: Vec<String>,
+}
+
+/// JSON payload for the `dryRunHandle` op — same message + metadata as
+/// `submit`, minus the node/proof endpoints (no transaction is built).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DryRunHandleRequest<'a> {
+    /// Operation discriminator.
+    pub op: &'static str,
+    /// Deployed WarpRoute contract address.
+    pub contract_address: String,
+    /// Indexer GraphQL endpoint (HTTP).
+    pub indexer_graphql_url: String,
+    /// Indexer GraphQL endpoint (WebSocket).
+    pub indexer_ws_url: String,
+    /// Midnight network id.
+    pub network_id: String,
+    /// Hyperlane message.
+    pub message: WireMessage<'a>,
+    /// MessageIdMultisigIsm metadata.
+    pub metadata: WireMetadata,
+    /// Whether the recipient is a contract address.
+    pub is_contract_recipient: bool,
+}
+
+/// JSON envelope returned by the `dryRunHandle` op.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DryRunResponse {
+    /// `true` when the message would be accepted on-chain (no revert).
+    #[serde(default)]
+    pub ok: Option<bool>,
+    /// Structured error when the message would revert, or on a transport
+    /// failure talking to the indexer.
+    #[serde(default)]
+    pub error: Option<SubmitError>,
 }
 
 /// JSON envelope returned by the `submit` op.
@@ -513,6 +553,22 @@ async fn run_submitter<R: Serialize>(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Build the wire-format message shared by the `submit` and `dryRunHandle`
+/// payloads. `sender`/`recipient` keep the `0x` prefix (only the contract
+/// address is bare-hex at the Midnight-SDK seam — see `query_delivered`).
+fn wire_message(message: &HyperlaneMessage) -> WireMessage<'_> {
+    WireMessage {
+        version: message.version,
+        nonce: message.nonce.to_string(),
+        origin: message.origin,
+        sender: format!("0x{:x}", message.sender),
+        destination: message.destination,
+        recipient: format!("0x{:x}", message.recipient),
+        body: format!("0x{}", hex::encode(&message.body)),
+        _marker: std::marker::PhantomData,
+    }
+}
+
 /// Build a `SubmitRequest` from a HyperlaneMessage + metadata.
 pub fn build_request<'a>(
     contract_address: H256,
@@ -530,18 +586,67 @@ pub fn build_request<'a>(
         node_rpc_url: ctx.node_rpc_url.clone(),
         proof_server_url: ctx.proof_server_url.clone(),
         network_id: ctx.network_id.clone(),
-        message: WireMessage {
-            version: message.version,
-            nonce: message.nonce.to_string(),
-            origin: message.origin,
-            sender: format!("0x{:x}", message.sender),
-            destination: message.destination,
-            recipient: format!("0x{:x}", message.recipient),
-            body: format!("0x{}", hex::encode(&message.body)),
-            _marker: std::marker::PhantomData,
-        },
+        message: wire_message(message),
         metadata,
         is_contract_recipient,
+    }
+}
+
+/// Build a `DryRunHandleRequest` mirroring `build_request` so the dry-run
+/// executes exactly what `process` would submit — only the op and the
+/// absence of node/proof endpoints differ.
+pub fn build_dry_run_request<'a>(
+    contract_address: H256,
+    ctx: &ToolkitContext,
+    message: &'a HyperlaneMessage,
+    metadata: WireMetadata,
+    is_contract_recipient: bool,
+) -> DryRunHandleRequest<'a> {
+    DryRunHandleRequest {
+        op: "dryRunHandle",
+        contract_address: format!("{contract_address:x}"),
+        indexer_graphql_url: ctx.indexer_graphql_url.clone(),
+        indexer_ws_url: ctx.indexer_ws_url.clone(),
+        network_id: ctx.network_id.clone(),
+        message: wire_message(message),
+        metadata,
+        is_contract_recipient,
+    }
+}
+
+/// Dry-run `handle` against current chain state via the submitter, WITHOUT
+/// proving or submitting. `Ok(())` means the message would be accepted
+/// on-chain; `Err` means it would revert (mapped from the submitter's
+/// structured error) or the submitter failed. The relayer's
+/// `process_estimate_costs` uses this so a reverting message is caught at
+/// prepare time and backs off instead of busy-looping (issue #80).
+pub async fn dry_run_handle(
+    ctx: &ToolkitContext,
+    request: &DryRunHandleRequest<'_>,
+) -> ChainResult<()> {
+    let raw = run_submitter(ctx, request, DRY_RUN_TIMEOUT).await?;
+    let response: DryRunResponse =
+        serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
+            message: err.to_string(),
+            raw: truncate(&raw, 1024),
+        })?;
+
+    if let Some(error) = response.error {
+        return Err(HyperlaneMidnightError::SubmitterReported {
+            kind: error.kind,
+            message: error.message,
+        }
+        .into());
+    }
+
+    if response.ok == Some(true) {
+        Ok(())
+    } else {
+        Err(HyperlaneMidnightError::SubmitterMalformed {
+            message: "dryRunHandle response missing both `ok` and `error`".to_string(),
+            raw: truncate(&raw, 1024),
+        }
+        .into())
     }
 }
 
@@ -689,4 +794,97 @@ mod tests {
         let display = format!("{err}");
         assert!(display.contains("timeout") || display.contains("SIGKILL"));
     }
+
+    // Write an executable mock submitter that prints `json_response` on
+    // stdout, mirroring the inline scripts above. Caller removes the file.
+    fn write_mock_submitter(tag: &str, json_response: &str) -> std::path::PathBuf {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let path =
+            std::env::temp_dir().join(format!("midnight-toolkit-{tag}-{}.sh", std::process::id()));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(format!("#!/bin/sh\necho '{json_response}'\n").as_bytes())
+            .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    fn sample_message() -> HyperlaneMessage {
+        HyperlaneMessage {
+            version: 3,
+            nonce: 42,
+            origin: 5,
+            sender: H256::from_low_u64_be(0xAB),
+            destination: 1234,
+            recipient: H256::from_low_u64_be(0xCD),
+            body: vec![0u8; 64],
+        }
+    }
+
+    #[test]
+    fn build_dry_run_request_serializes_to_expected_shape() {
+        let msg = sample_message();
+        let request = build_dry_run_request(H256::from_low_u64_be(1), &ctx(), &msg, metadata(), false);
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"op\":\"dryRunHandle\""));
+        assert!(json.contains("\"version\":3"));
+        assert!(json.contains("\"isContractRecipient\":false"));
+        // The dry-run payload omits the node/proof endpoints — no tx is built.
+        assert!(!json.contains("nodeRpcUrl"));
+        assert!(!json.contains("proofServerUrl"));
+    }
+
+    // `{"ok":true}` -> the message would be accepted -> `Ok(())`, which the
+    // relayer reads as "gas estimate succeeded, proceed".
+    #[tokio::test]
+    async fn dry_run_ok_response_is_ok() {
+        let script = write_mock_submitter("dryrun-ok", "{\"ok\":true}");
+        let mut ctx = ctx();
+        ctx.binary_path = script.to_string_lossy().into_owned();
+        let msg = sample_message();
+        let request = build_dry_run_request(H256::zero(), &ctx, &msg, metadata(), false);
+        let result = dry_run_handle(&ctx, &request).await;
+        let _ = std::fs::remove_file(&script);
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    // A structured revert error -> `Err` carrying the kind + message, which
+    // the relayer turns into `ErrorEstimatingGas` -> exponential backoff.
+    #[tokio::test]
+    async fn dry_run_error_response_maps_to_submitter_reported() {
+        let script = write_mock_submitter(
+            "dryrun-revert",
+            "{\"error\":{\"kind\":\"contractRevert\",\"message\":\"Mailbox: bad version\"}}",
+        );
+        let mut ctx = ctx();
+        ctx.binary_path = script.to_string_lossy().into_owned();
+        let msg = sample_message();
+        let request = build_dry_run_request(H256::zero(), &ctx, &msg, metadata(), false);
+        let err = dry_run_handle(&ctx, &request).await.unwrap_err();
+        let _ = std::fs::remove_file(&script);
+        let display = format!("{err}");
+        assert!(display.contains("contractRevert"), "unexpected error: {display}");
+        assert!(display.contains("bad version"), "unexpected error: {display}");
+    }
+
+    // Neither `ok` nor `error` -> malformed. Defensive: the Node op always
+    // sends one or the other, so this only fires on a protocol drift.
+    #[tokio::test]
+    async fn dry_run_missing_ok_and_error_is_malformed() {
+        let script = write_mock_submitter("dryrun-empty", "{}");
+        let mut ctx = ctx();
+        ctx.binary_path = script.to_string_lossy().into_owned();
+        let msg = sample_message();
+        let request = build_dry_run_request(H256::zero(), &ctx, &msg, metadata(), false);
+        let err = dry_run_handle(&ctx, &request).await.unwrap_err();
+        let _ = std::fs::remove_file(&script);
+        let display = format!("{err:?}").to_lowercase();
+        assert!(
+            display.contains("missing") || display.contains("malformed"),
+            "unexpected error: {display}"
+        );
+    }
+
+    // The submitter-timeout / SIGKILL path is shared with all ops via
+    // `run_submitter`, covered by `timeout_elapses_and_kills_child` above.
 }


### PR DESCRIPTION
## Problem (issue #80)

An inbound message whose `handle` reverts at submit time (unenrolled sender, amount over escrow, paused, ...) was retried by the relayer with **no backoff** (~every 4-5s), dominating the submission queue and starving all other inbound delivery to Midnight. `MidnightMailbox::process_estimate_costs` was a static stub that always returned `Ok`, so the revert never surfaced at prepare time (where the standard `ErrorEstimatingGas` -> exponential backoff applies); it only hit the submit-time `ErrorSubmitting` path, which doesn't increment the retry counter. Production DoS vector.

## Fix

Implement a real `process_estimate_costs` that **dry-runs `handle`** against current chain state via the submitter's new `dryRunHandle` op (no proving, no submission — the same local-execution mechanism as the `isDelivered` read). On a would-revert it returns `Err`, so the relayer catches it at prepare time and backs off like every other Hyperlane chain. Metadata is parsed + validator-index sorted exactly as `process` does; cost values stay the fixed DUST placeholder on success.

- `toolkit.rs`: `dry_run_handle` + `build_dry_run_request` (modeled on `query_delivered`), `DryRunHandleRequest`/`DryRunResponse`.
- `mailbox.rs`: real `process_estimate_costs`.
- `cross_boundary_tests.rs`: dry-run ok / revert-maps-to-error / unparseable-metadata + updated placeholder test.

Pairs with the `equilibriumco/hyperlane-midnight` PR (the `dryRunHandle` op in the Node submitter + escrow pre-check).

## Validation

- `cargo test -p hyperlane-midnight`: 76 pass; clippy clean.
- **Live**: the full inbound E2E suite (11 tests) passes against a relayer built from this branch, including the `inbound-starvation` regression (rogue backs off, legit delivers).

Bump `scripts/hyperlane-monorepo.sha` in the contracts repo to this commit to pick up the fix.
