### PR TITLE
feat(#34): seed midnight + test4 domain rows for the scraper store

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -520,6 +520,30 @@ const DOMAINS: &[RawDomain] = &[
         chain_id: 1212538671,
         is_test_net: true,
         is_deprecated: false,
+    },
+    // Midnight (#34). `chain_id` mirrors the domain: Midnight has no EVM
+    // chain id, but a NULL here leaves `message_view.origin_chain_id` unset
+    // and the Explorer's timeline never leaves its first stage. Domain 1234
+    // is `KnownHyperlaneDomain::Midnight`, shared by the local devnet and
+    // the stagenet deployment.
+    RawDomain {
+        name: "midnight",
+        token: "NIGHT",
+        domain: 1234,
+        chain_id: 1234,
+        is_test_net: true,
+        is_deprecated: false,
+    },
+    // The Anvil chain the Midnight E2E environments pair with Midnight. It is
+    // scraped alongside it so `delivered_message` rows — and therefore the
+    // delivery half of `message_view` — resolve for Midnight-origin messages.
+    RawDomain {
+        name: "test4",
+        token: "ETH",
+        domain: 31337,
+        chain_id: 31337,
+        is_test_net: true,
+        is_deprecated: false,
     }, // ---------- End: E2E tests chains ----------------
 ];
 


### PR DESCRIPTION
Unblocks scraper support for Midnight (equilibriumco/hyperlane-midnight#34).

## Why this is the only change needed here

The scraper agent has no protocol-specific code at all — `git grep 'HyperlaneDomainProtocol\|domain_protocol' -- rust/main/agents/scraper/src` returns nothing. Everything it consumes for Midnight already landed with #95 (PR #41):

- the only four builders it calls (`agents/scraper/src/agent.rs:289`, `:356`, `:491`, `:534`) have real Midnight arms — `build_provider` (`chains.rs:375`), `build_message_indexer` (`:652`), `build_delivery_indexer` (`:747`), `build_interchain_gas_payment_indexer` (`:932`);
- the only two provider methods its store calls (`store/storage.rs:150`, `:243`) are real — `MidnightProvider::get_block_by_height` / `get_txn_by_hash`, including the mandatory `receipt: Some(..)` that `db/txn.rs:76` hard-errors without;
- every `LogMeta` carries a non-zero `transaction_id`, without which `store/storage.rs:149` silently drops the log;
- `agents/scraper/Cargo.toml:51` already declares `midnight`, and `rust/Dockerfile:58` already builds `--features aleo,midnight --bin scraper`.

It also never builds a `Mailbox`, `MerkleTreeHook`, ISM or `ValidatorAnnounce`, so nothing else in the chain crate is on its path.

## What was actually missing

`domain` seed rows. `block.domain`, `cursor.domain`, `message.origin`, `delivered_message.domain` and `gas_payment.domain` are all foreign keys to `domain.id`, so a chain with no row cannot be scraped: the first insert violates a constraint and the cursor write fails with a warning only (`db/block_cursor.rs:99` — "ensure that the migrations included this domain"), leaving the agent looking healthy while storing nothing.

Two rows are added to the existing seed const, the same way `starknettest*`, `radixtest0/1`, `trontest1/2` and `cosmostestnative1/2` were:

- `midnight` / NIGHT / 1234 — `KnownHyperlaneDomain::Midnight`, shared by the local devnet and the stagenet deployment.
- `test4` / ETH / 31337 — the Anvil chain the Midnight E2E environments pair with. Needed because `message_view` LEFT JOINs the destination domain and delivery rows come from the *destination* chain's indexer, so scraping Midnight alone leaves every Midnight-origin message reading as undelivered.

`chain_id` mirrors the domain rather than being left NULL: `message_view.origin_chain_id` feeds the Explorer's message timeline, which gates on a truthy chain id.

## Verification

`cargo test --features midnight -p scraper -p migration -p hyperlane-midnight` — green (27 passed, 1 pre-existing `#[ignore]` on the stale `night-state.hex` fixture from #22).

Verified live end-to-end against the stagenet <-> Sepolia bridge's real on-chain traffic: all three Midnight event types indexed (`message` + `raw_message_dispatch`, `gas_payment`, `delivered_message`), real block/transaction rows, a persisted cursor, and `message_view` resolving both legs. A local Hyperlane Explorer over that database renders the Midnight-origin message as delivered with `0.2 NIGHT` paid at Midnight's 6 decimals.

Note the seed only runs on a fresh database. Long-lived deployments add domains with a hand-run INSERT instead — `typescript/infra/scripts/generate-scraper-add-domain-sql.sh`.