### PR TITLE
feat(#34): seed midnight + test4 domain rows for the scraper store

### DIFF
--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -520,6 +520,30 @@ const DOMAINS: &[RawDomain] = &[
         chain_id: 1212538671,
         is_test_net: true,
         is_deprecated: false,
+    },
+    // Midnight (#34). `chain_id` mirrors the domain: Midnight has no EVM
+    // chain id, but a NULL here leaves `message_view.origin_chain_id` unset
+    // and the Explorer's timeline never leaves its first stage. Domain 1234
+    // is `KnownHyperlaneDomain::Midnight`, shared by the local devnet and
+    // the stagenet deployment.
+    RawDomain {
+        name: "midnight",
+        token: "NIGHT",
+        domain: 1234,
+        chain_id: 1234,
+        is_test_net: true,
+        is_deprecated: false,
+    },
+    // The Anvil chain the Midnight E2E environments pair with Midnight. It is
+    // scraped alongside it so `delivered_message` rows — and therefore the
+    // delivery half of `message_view` — resolve for Midnight-origin messages.
+    RawDomain {
+        name: "test4",
+        token: "ETH",
+        domain: 31337,
+        chain_id: 31337,
+        is_test_net: true,
+        is_deprecated: false,
     }, // ---------- End: E2E tests chains ----------------
 ];
 

--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -521,8 +521,8 @@ const DOMAINS: &[RawDomain] = &[
         is_test_net: true,
         is_deprecated: false,
     },
-    // Midnight (#34). `chain_id` mirrors the domain: Midnight has no EVM
-    // chain id, but a NULL here leaves `message_view.origin_chain_id` unset
+    // Midnight. `chain_id` mirrors the domain: Midnight has no EVM chain
+    // id, but a NULL here leaves `message_view.origin_chain_id` unset
     // and the Explorer's timeline never leaves its first stage. Domain 1234
     // is `KnownHyperlaneDomain::Midnight`, shared by the local devnet and
     // the stagenet deployment.

--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -522,10 +522,10 @@ const DOMAINS: &[RawDomain] = &[
         is_deprecated: false,
     },
     // Midnight. `chain_id` mirrors the domain: Midnight has no EVM chain
-    // id, but a NULL here leaves `message_view.origin_chain_id` unset
-    // and the Explorer's timeline never leaves its first stage. Domain 1234
-    // is `KnownHyperlaneDomain::Midnight`, shared by the local devnet and
-    // the stagenet deployment.
+    // id, but a NULL here leaves `message_view.origin_chain_id` unset,
+    // and the Explorer's message queries read that column as non-nullable.
+    // Domain 1234 is `KnownHyperlaneDomain::Midnight`, shared by the local
+    // devnet and the stagenet deployment.
     RawDomain {
         name: "midnight",
         token: "NIGHT",


### PR DESCRIPTION
Replaces the closed #42 (same branch, unchanged commit `208ceb128`) — the #34 restart reuses the seed rows as-is. Every scraper table FK-references `domain.id`, so without these rows the first insert violates the constraint and the chain silently stores nothing; `test4` is seeded because `message_view` resolves delivery from the destination chain's indexer. Verified live 2026-07-28: a fresh scraper DB seeds both rows, the domain assertion in the runbook passes, and the scraper indexed the outbound roundtrip leg. Companion: equilibriumco/hyperlane-midnight PR #101.