### PR TITLE
feat(#105): accept node signer type + env-driven announce timeout

### DIFF
--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -9,9 +9,10 @@ use hyperlane_core::{ChainResult, HyperlaneMessage, H160, H256, H512};
 
 use crate::HyperlaneMidnightError;
 
-/// How long the relayer waits for the submitter subprocess to build the handle
-/// proof and land the tx. A real handle proof (multisig + ZK verify) can take
-/// many minutes on a RAM-constrained host, so this is overridable via
+/// How long an agent waits for the submitter subprocess to build a proof and
+/// land the tx — the relayer's `handle` submissions and the validator's
+/// self-announce alike. A real proof (multisig + ZK verify) can take many
+/// minutes on a RAM-constrained host, so this is overridable via
 /// `MIDNIGHT_SUBMIT_TIMEOUT_SECS` (default 120s) — mirrors the proof server's
 /// own `MIDNIGHT_PROOF_SERVER_JOB_TIMEOUT`.
 fn submit_timeout() -> Duration {
@@ -23,7 +24,6 @@ fn submit_timeout() -> Duration {
     )
 }
 const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
-const ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(120);
 const STORAGE_LOCATIONS_TIMEOUT: Duration = Duration::from_secs(60);
 // Dry-run fetches state and executes `handle` locally (keccak/ecrecover
 // witnesses, no proving, no broadcast) — heavier than the `isDelivered`
@@ -411,7 +411,7 @@ pub async fn announce_tx(
         pubkey: format!("0x{}", hex::encode(pubkey)),
     };
 
-    let raw = run_submitter(ctx, &request, ANNOUNCE_TIMEOUT).await?;
+    let raw = run_submitter(ctx, &request, submit_timeout()).await?;
     let response: SubmitResponse =
         serde_json::from_str(&raw).map_err(|err| HyperlaneMidnightError::SubmitterMalformed {
             message: err.to_string(),

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -560,6 +560,9 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
         Some("cosmosKey") => parse_signer!(cosmosKey),
         Some("starkKey") => parse_signer!(starkKey),
         Some("radixKey") => parse_signer!(radixKey),
+        // The TS SDK's AgentSignerNodeSchema emits an explicit
+        // `{"type": "node"}`; accept it alongside the bare `{}` form.
+        Some("node") => Ok(SignerConf::Node),
         Some(t) => {
             Err(eyre!("Unknown signer type `{t}`")).into_config_result(|| (&signer.cwp).add("type"))
         }


### PR DESCRIPTION
Unblocks validator self-announce on Midnight (#105): the announce plumbing (480-byte pad -> pubkey recovery -> toolkit `announce` op) has existed since #90 but could never run — no parseable config could hand the validator a signer, and the proof would have been killed mid-flight.

## What changed

- **`{"type": "node"}` parses as `SignerConf::Node`**: the TS SDK's `AgentSignerNodeSchema` emits an explicit `type: node`, but `parse_signer` only produced `SignerConf::Node` for a bare key-less signer object and rejected the explicit form with "Unknown signer type". With a signer present, the validator's announce loop submits instead of warning "Cannot announce validator without a signer" forever.
- **Announce timeout follows `MIDNIGHT_SUBMIT_TIMEOUT_SECS`**: the announce subprocess ran under a hardcoded 120s timeout; a real announce proof (~560 MiB prover key) takes minutes on RAM-constrained hosts. It now uses the same env-overridable timeout as every other submission.

## Testing

- `cargo check -p hyperlane-midnight -p hyperlane-base` clean (pre-existing warnings only).
- The config side (signer entry on the midnight chain entries, validator process env) lands with the integration configs; a live devnet self-announce run is the remaining verification there.