### PR TITLE
fix(midnight): name both sidecar seed vars in the signer error

### DIFF
--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -403,8 +403,9 @@ impl BuildableWithSignerConf for hyperlane_midnight::MidnightSigner {
             _ => bail!(format!(
                 "{conf:?} is not supported by midnight; use signer type `node` \
                  (transaction signing is delegated to the handle-submitter \
-                  subprocess; relayer wallet seed comes from \
-                  `MIDNIGHT_RELAYER_SEED`)"
+                  subprocess; the relayer wallet seed comes from \
+                  `MIDNIGHT_RELAYER_SEED`, the validator's announce wallet \
+                  from `MIDNIGHT_VALIDATOR_SEED`)"
             )),
         }
     }


### PR DESCRIPTION
The signer-misconfiguration error pointed only at MIDNIGHT_RELAYER_SEED. The sidecar now signs validator announcements with a separate MIDNIGHT_VALIDATOR_SEED wallet (hyperlane-midnight change), so the hint names both.