### PR TITLE
fix(cli): carry token scale into generated warp core configs

### DIFF
--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -450,6 +450,7 @@ function generateTokenConfigs(
       standard: tokenTypeToStandard(protocol as ProtocolType, config.type),
       tokenType: config.type,
       decimals: tokenMetadataMap.getDecimals(chainName)!,
+      scale: tokenMetadataMap.getScale(chainName),
       symbol: config.symbol || tokenMetadataMap.getSymbol(chainName)!,
       name: tokenMetadataMap.getName(chainName)!,
       addressOrDenom: contracts[chainName],


### PR DESCRIPTION
generateTokenConfigs copies decimals, symbol, and name from the derived token metadata into the warp core config it writes to the registry, but never scale. On routes where decimals differ across chains (Midnight's 6 vs an EVM synthetic's 18), the written config then renders raw wire amounts in any consumer that is scale-aware, and the field has to be added by hand after every deploy.

The metadata map already carries scale when the deploy config provides it and validates it against the route's decimals in finalize(), so this only forwards the existing value; chains without scale are unaffected (the field stays absent).

Verified by running deriveTokenMetadata on the live NIGHT route's deploy config: the emitted values match the hand-maintained registry entry (midnight NIGHT/6/1e12, sepolia sNIGHT/18/no scale) and WarpCoreConfigSchema accepts the scale field.