### PR TITLE
fix(docker): copy the midnight-sdk package manifest before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY typescript/helloworld/package.json ./typescript/helloworld/
 COPY typescript/http-registry-server/package.json ./typescript/http-registry-server/
 COPY typescript/infra/package.json ./typescript/infra/
 COPY typescript/keyfunder/package.json ./typescript/keyfunder/
+COPY typescript/midnight-sdk/package.json ./typescript/midnight-sdk/
 COPY typescript/provider-sdk/package.json ./typescript/provider-sdk/
 COPY typescript/radix-sdk/package.json ./typescript/radix-sdk/
 COPY typescript/tron-sdk/package.json ./typescript/tron-sdk/


### PR DESCRIPTION
check-package-json compares workspace packages against the Dockerfile's manifest COPY block; typescript/midnight-sdk was never added there, so the check has been failing on midnight-v1 since the package landed. One line, same pattern as the other workspaces.