### PR TITLE
chore: trim the Midnight comments down to what is worth reading

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -746,12 +746,9 @@ impl PendingMessage {
         origin_db: Arc<dyn HyperlaneDb>,
         message: &HyperlaneMessage,
     ) -> PendingOperationStatus {
-        // Level for the db-status trace events: DEBUG under test-utils (so
-        // E2E tests can assert on the log) and TRACE otherwise. Defined as a
-        // cfg-selected const rather than an inline `if cfg!(...)` inside the
-        // event! macro: the inline conditional creates a temporary that fails
-        // to compile on rustc >= 1.89 (E0716 "temporary value dropped while
-        // borrowed"). This const form compiles on 1.88 and 1.89 alike.
+        // A const rather than an inline `if cfg!(...)` in the `event!` macro:
+        // the inline form creates a temporary that fails to compile on rustc
+        // 1.89 with E0716.
         #[cfg(feature = "test-utils")]
         const DB_STATUS_LEVEL: Level = Level::DEBUG;
         #[cfg(not(feature = "test-utils"))]

--- a/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
+++ b/rust/main/agents/scraper/migration/src/m20230309_000001_create_table_domain.rs
@@ -521,11 +521,9 @@ const DOMAINS: &[RawDomain] = &[
         is_test_net: true,
         is_deprecated: false,
     },
-    // Midnight. `chain_id` mirrors the domain: Midnight has no EVM chain
-    // id, but a NULL here leaves `message_view.origin_chain_id` unset,
-    // and the Explorer's message queries read that column as non-nullable.
-    // Domain 1234 is `KnownHyperlaneDomain::Midnight`, shared by the local
-    // devnet and the stagenet deployment.
+    // Midnight has no EVM chain id, so `chain_id` mirrors the domain: a NULL
+    // leaves `message_view.origin_chain_id` unset, which the Explorer's message
+    // queries read as non-nullable.
     RawDomain {
         name: "midnight",
         token: "NIGHT",
@@ -534,9 +532,8 @@ const DOMAINS: &[RawDomain] = &[
         is_test_net: true,
         is_deprecated: false,
     },
-    // The Anvil chain the Midnight E2E environments pair with Midnight. It is
-    // scraped alongside it so `delivered_message` rows — and therefore the
-    // delivery half of `message_view` — resolve for Midnight-origin messages.
+    // The Anvil chain the Midnight E2E environments pair with, scraped
+    // alongside it so the delivery half of `message_view` resolves.
     RawDomain {
         name: "test4",
         token: "ETH",

--- a/rust/main/chains/hyperlane-midnight/src/application.rs
+++ b/rust/main/chains/hyperlane-midnight/src/application.rs
@@ -1,12 +1,7 @@
 //! Application-level message verification for Midnight.
 //!
-//! The relayer calls into [`ApplicationOperationVerifier`] before delivering a
-//! message to its destination, so each chain integration can reject messages
-//! that its on-chain runtime would refuse anyway (e.g. malformed bodies).
-//!
-//! For Midnight, the only structural constraint we enforce at this layer is
-//! that warp-route messages must carry a parseable [`TokenMessage`]. Anything
-//! else is left to the on-chain Mailbox + ISM + WarpRoute to handle.
+//! The only constraint enforced here is that warp-route messages carry a
+//! parseable [`TokenMessage`]; everything else is left to the contract.
 
 use std::io::Cursor;
 

--- a/rust/main/chains/hyperlane-midnight/src/config.rs
+++ b/rust/main/chains/hyperlane-midnight/src/config.rs
@@ -10,9 +10,8 @@ pub struct ConnectionConf {
 }
 
 impl ConnectionConf {
-    /// Construct a new `ConnectionConf`. Validators and threshold are no
-    /// longer config-sourced — the ISM reads them from on-chain state via
-    /// the indexer.
+    /// Construct a new `ConnectionConf`. Validators and threshold are not
+    /// configured here; the ISM reads them from chain state.
     pub fn new(indexer_graphql_url: Url, toolkit_path: Option<String>) -> Self {
         Self {
             indexer_graphql_url,

--- a/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
+++ b/rust/main/chains/hyperlane-midnight/src/cross_boundary_tests.rs
@@ -114,8 +114,8 @@ async fn delivered_propagates_submitter_error_as_structured_kind() {
 
 #[tokio::test]
 async fn is_contract_returns_true_for_monolithic_warp_route() {
-    // Returning false makes `pending_message` drop every inbound message
-    // at the `is_recipient_contract` gate before `Mailbox::process` runs.
+    // `false` would make the relayer drop every inbound message at its
+    // `is_recipient_contract` gate, before `process` ever runs.
     let stub = StubSubmitter::always_returns("{}");
     let mailbox = build_mailbox(&stub);
     let is_contract = mailbox
@@ -162,8 +162,7 @@ async fn process_request_json_pins_wire_shape() {
     assert_eq!(md["index"], 7);
 
     let sigs = md["signatures"].as_array().unwrap();
-    // No zero-padding: the relayer forwards exactly the real signatures; the
-    // Midnight submitter pads the on-chain `Vector<4>` by repeating slot 0 (#22).
+    // Forwarded unpadded; the submitter pads the on-chain `Vector<4>`.
     assert_eq!(sigs.len(), 2);
     assert_eq!(
         sigs[0].as_str().unwrap(),
@@ -278,9 +277,8 @@ async fn count_returns_zero_for_destination_only_impl() {
     assert_eq!(mailbox.count(&ReorgPeriod::None).await.unwrap(), 0);
 }
 
-// An accepting dry-run returns `{"ok":true}` and the estimate reports zero
-// cost. The request must be the `dryRunHandle` op, proving the estimate
-// simulates rather than blindly succeeding.
+// The request must be the `dryRunHandle` op, or the estimate is succeeding
+// blindly rather than simulating.
 #[tokio::test]
 async fn process_estimate_costs_dry_runs_and_returns_placeholder_on_accept() {
     let stub = StubSubmitter::always_returns(r#"{"ok":true}"#);
@@ -300,10 +298,8 @@ async fn process_estimate_costs_dry_runs_and_returns_placeholder_on_accept() {
     assert!(req.get("proofServerUrl").is_none());
 }
 
-// The #80 fix, at the mailbox seam: a dry-run that detects a revert returns
-// `Err`, which `pending_message::prepare` maps to `ErrorEstimatingGas` and then
-// backs off — instead of the revert only surfacing at submit time on the
-// no-backoff path where it would busy-loop and starve other deliveries.
+// A detected revert has to error here, so the relayer maps it to
+// `ErrorEstimatingGas` and backs off instead of busy-looping at submit time.
 #[tokio::test]
 async fn process_estimate_costs_errs_when_dry_run_detects_revert() {
     let stub = StubSubmitter::always_returns(
@@ -325,8 +321,8 @@ async fn process_estimate_costs_errs_when_dry_run_detects_revert() {
     );
 }
 
-// Metadata too short to parse fails before the dry-run, so a structurally
-// broken message also errors (backs off) rather than reaching submit.
+// Unparseable metadata fails before the dry run, so a structurally broken
+// message backs off too rather than reaching submit.
 #[tokio::test]
 async fn process_estimate_costs_errs_on_unparseable_metadata() {
     let stub = StubSubmitter::always_returns(r#"{"ok":true}"#);

--- a/rust/main/chains/hyperlane-midnight/src/events.rs
+++ b/rust/main/chains/hyperlane-midnight/src/events.rs
@@ -1,21 +1,9 @@
-//! Decoding of the WarpRoute/IGP contracts' `HYP_*` Misc events into
-//! Hyperlane domain types, plus the shared [`LogMeta`] mapping and the
-//! event-reader seam the dispatch/delivery/IGP/merkle indexers share.
+//! Decoding of the `HYP_*` Misc events into Hyperlane domain types, plus the
+//! shared [`LogMeta`] mapping and the reader seam the indexers share.
 //!
-//! The contracts emit one Misc event per state transition, atomically with
-//! the corresponding ledger write:
-//!
-//!   - `HYP_DISPATCH`: payload `[0..141)` is the encoded `HyperlaneMessage`
-//!     wire form (the exact bytes `HyperlaneMessage::read_from` decodes;
-//!     the nonce is inside it).
-//!   - `HYP_PROCESS`: payload `[0..32)` is the delivered message id.
-//!   - `HYP_GAS_PAYMENT`: payload `[0..32)` messageId, `[32..36)`
-//!     destination u32 BE, `[36..44)` gasAmount u64 BE, `[44..60)` payment
-//!     u128 BE.
-//!
-//! Payloads are zero-padded to 256 bytes by the indexer, so decoding is a
-//! fixed-offset slice. The standard `Paused`/`Unpaused` ledger events have no
-//! Hyperlane consumer and are filtered out server-side (`types: [MISC]`).
+//! The contracts emit one event per state transition, atomically with the
+//! matching ledger write. Payloads are zero-padded to 256 bytes, so every
+//! decode is a fixed-offset slice.
 
 use async_trait::async_trait;
 
@@ -27,21 +15,15 @@ use crate::indexer_client::{MidnightIndexerClient, MiscEvent};
 use crate::state_decode::ENCODED_MESSAGE_LEN;
 use crate::HyperlaneMidnightError;
 
-/// Event name for a Mailbox dispatch.
 pub(crate) const HYP_DISPATCH: &str = "HYP_DISPATCH";
-/// Event name for a Mailbox delivery.
 pub(crate) const HYP_PROCESS: &str = "HYP_PROCESS";
-/// Event name for an IGP gas payment.
 pub(crate) const HYP_GAS_PAYMENT: &str = "HYP_GAS_PAYMENT";
 
-/// Length of a `HYP_PROCESS` payload's message id.
 const PROCESS_PAYLOAD_LEN: usize = 32;
-/// Length of a `HYP_GAS_PAYMENT` payload record.
 const GAS_PAYMENT_PAYLOAD_LEN: usize = 60;
 
-/// Whether `event` carries the given ASCII name (zero-padded to the 32-byte
-/// wire width). A name that merely shares the prefix (e.g. a hypothetical
-/// `HYP_DISPATCH2`) does NOT match: the padding must be all zeros.
+/// A name that merely shares the prefix does not match: the padding out to the
+/// 32-byte wire width has to be all zeros.
 pub(crate) fn has_name(event: &MiscEvent, name: &str) -> bool {
     let bytes = name.as_bytes();
     if bytes.len() > event.name.len() {
@@ -50,15 +32,9 @@ pub(crate) fn has_name(event: &MiscEvent, name: &str) -> bool {
     event.name[..bytes.len()] == *bytes && event.name[bytes.len()..].iter().all(|b| *b == 0)
 }
 
-/// Build the real per-event [`LogMeta`]:
-///
-///   - `block_number`/`block_hash`: the block the emitting tx landed in;
-///   - `transaction_id`: the tx hash, widened `H256` -> `H512` (right-aligned,
-///     as other non-EVM chains do);
-///   - `transaction_index`: the indexer-global transaction `id` (monotonic
-///     integer, not a per-block index — Midnight's stable per-tx ordinal);
-///   - `log_index`: the chain-global monotonic event `id` (sparse per
-///     contract; other event kinds share the sequence).
+/// Two fields do not mean what their names suggest: `transaction_index` is the
+/// indexer-global transaction id rather than a per-block index, and `log_index`
+/// is the chain-global event id, which is sparse per contract.
 pub(crate) fn event_log_meta(event: &MiscEvent, address: H256) -> LogMeta {
     LogMeta {
         address,
@@ -70,25 +46,20 @@ pub(crate) fn event_log_meta(event: &MiscEvent, address: H256) -> LogMeta {
     }
 }
 
-/// Decode a `HYP_DISPATCH` payload into the dispatched [`HyperlaneMessage`].
-/// The wire form is exactly [`ENCODED_MESSAGE_LEN`] bytes, so the slice must
-/// be exact: `read_from` treats everything after the fixed header as the
-/// body, and the zero padding beyond 141 is NOT part of the message.
+/// The slice has to be exactly [`ENCODED_MESSAGE_LEN`] bytes: `read_from` treats
+/// everything after the header as body, so trailing padding would be swallowed
+/// into it.
 pub(crate) fn decode_dispatch_event(event: &MiscEvent) -> ChainResult<HyperlaneMessage> {
     let payload = payload_slice(event, ENCODED_MESSAGE_LEN, HYP_DISPATCH)?;
     HyperlaneMessage::read_from(&mut &payload[..])
         .map_err(|e| HyperlaneMidnightError::StateDecode(e.to_string()).into())
 }
 
-/// Decode a `HYP_PROCESS` payload into the delivered message id.
 pub(crate) fn decode_process_event(event: &MiscEvent) -> ChainResult<H256> {
     let payload = payload_slice(event, PROCESS_PAYLOAD_LEN, HYP_PROCESS)?;
     Ok(H256::from_slice(payload))
 }
 
-/// Decode a `HYP_GAS_PAYMENT` payload into an [`InterchainGasPayment`]
-/// (big-endian fields, mirroring `HyperlaneEvents.compact`'s u32BE/u64BE/
-/// u128BE encoders).
 pub(crate) fn decode_gas_payment_event(event: &MiscEvent) -> ChainResult<InterchainGasPayment> {
     let payload = payload_slice(event, GAS_PAYMENT_PAYLOAD_LEN, HYP_GAS_PAYMENT)?;
     let destination =
@@ -108,9 +79,6 @@ pub(crate) fn decode_gas_payment_event(event: &MiscEvent) -> ChainResult<Interch
     })
 }
 
-/// The leading `len` bytes of the event's zero-padded payload. Errors on a
-/// short payload (the indexer pads to 256, so this only fires on a malformed
-/// response) instead of panicking on slice bounds.
 fn payload_slice<'a>(event: &'a MiscEvent, len: usize, what: &str) -> ChainResult<&'a [u8]> {
     event.payload.get(..len).ok_or_else(|| {
         HyperlaneMidnightError::StateDecode(format!(
@@ -121,9 +89,8 @@ fn payload_slice<'a>(event: &'a MiscEvent, len: usize, what: &str) -> ChainResul
     })
 }
 
-/// Narrow a framework `H512` tx hash to Midnight's 32-byte hash. Hyperlane
-/// widens 32-byte hashes right-aligned (`From<H256> for H512`), so the upper
-/// 32 bytes must be zero; anything else cannot be a Midnight tx hash.
+/// Hyperlane widens 32-byte hashes right-aligned, so a non-zero upper half
+/// cannot be a Midnight tx hash.
 pub(crate) fn h512_to_h256(hash: H512) -> Option<H256> {
     if hash[..32].iter().any(|b| *b != 0) {
         return None;
@@ -131,41 +98,28 @@ pub(crate) fn h512_to_h256(hash: H512) -> Option<H256> {
     Some(H256::from(hash))
 }
 
-/// Render an `H256` contract address as the lowercase bare-hex string the
-/// indexer's `HexEncoded` scalar accepts, matching the convention every
-/// Midnight state/event read uses.
+/// The indexer's `HexEncoded` scalar takes bare hex, with no `0x`.
 pub(crate) fn address_hex(address: &H256) -> String {
     format!("{address:x}")
 }
 
-/// Map an indexer-reported block height to a `u32` tip. The indexer reports a
-/// `u64`; heights beyond `u32::MAX` saturate rather than truncate/wrap, and
-/// "no block observed yet" (`None`) maps to `0`.
 pub(crate) fn height_to_tip(height: Option<u64>) -> u32 {
     height
         .map(|h| u32::try_from(h).unwrap_or(u32::MAX))
         .unwrap_or(0)
 }
 
-/// The minimal reads the event-based indexers need from the Midnight indexer.
-/// Abstracting them behind a trait lets the dispatch/delivery/IGP/merkle
-/// indexer logic be unit-tested against synthetic in-memory events without
-/// network IO; production uses the [`MidnightIndexerClient`] impl below.
+/// Behind a trait so the indexer logic can be unit-tested against synthetic
+/// events with no network IO. Events from failed transactions never appear.
 #[async_trait]
 pub(crate) trait MidnightEventReader: Send + Sync {
-    /// Latest observed block height as a `u32` tip; heights beyond `u32::MAX`
-    /// saturate, and "no block seen yet" maps to `0`.
     async fn read_tip(&self) -> ChainResult<u32>;
-    /// Misc events the contract emitted in the inclusive block range, in
-    /// monotonic event-id order, FAILURE transactions already excluded.
     async fn misc_events(
         &self,
         address: &str,
         from_block: u32,
         to_block: u32,
     ) -> ChainResult<Vec<MiscEvent>>;
-    /// Misc events the contract emitted from the given transaction, FAILURE
-    /// transactions already excluded.
     async fn misc_events_by_tx(&self, address: &str, tx_hash: &H256)
         -> ChainResult<Vec<MiscEvent>>;
 }
@@ -207,9 +161,8 @@ pub(crate) mod test_util {
     use super::*;
     use crate::indexer_client::{TxStatus, MISC_NAME_LEN, MISC_PAYLOAD_LEN};
 
-    /// Build a synthetic [`MiscEvent`] with the given name and payload
-    /// content (zero-padded to the wire widths) and deterministic metadata
-    /// derived from `id`.
+    /// Metadata is derived from `id`, so a synthetic event sits at block
+    /// `1000 + id`.
     pub(crate) fn misc_event(id: u64, name: &str, payload_content: &[u8]) -> MiscEvent {
         let mut name_bytes = [0u8; MISC_NAME_LEN];
         name_bytes[..name.len()].copy_from_slice(name.as_bytes());
@@ -228,10 +181,6 @@ pub(crate) mod test_util {
         }
     }
 
-    /// A synthetic in-memory event reader: the unit-test seam that lets the
-    /// indexer logic run without network IO. `misc_events` honors the block
-    /// range against each event's `block_height`, mirroring the server-side
-    /// `fromBlock`/`toBlock` filter; `misc_events_by_tx` honors the tx hash.
     pub(crate) struct FakeEventReader {
         pub tip: u32,
         pub events: Vec<MiscEvent>,
@@ -286,9 +235,8 @@ mod tests {
             sender: H256::repeat_byte(0xAA),
             destination: 99,
             recipient: H256::repeat_byte(0xBB),
-            // 64-byte body ending in zeros: the message wire form ends in
-            // 0x00 bytes, pinning that the decoder slices the fixed 141-byte
-            // offset out of the zero-padded payload rather than trimming.
+            // A zero tail pins the fixed-offset slicing: trimming instead would
+            // read into the payload padding.
             body: {
                 let mut b = vec![0u8; 64];
                 b[0] = 0x11;
@@ -303,10 +251,8 @@ mod tests {
         let event = misc_event(1, HYP_DISPATCH, &[]);
         assert!(has_name(&event, HYP_DISPATCH));
         assert!(!has_name(&event, HYP_PROCESS));
-        // A shared prefix does not match: the tail must be all zeros.
         assert!(!has_name(&event, "HYP_"));
 
-        // A name with a non-zero byte after the ASCII prefix is different.
         let mut noisy = misc_event(2, HYP_DISPATCH, &[]);
         noisy.name[HYP_DISPATCH.len()] = 0x01;
         assert!(!has_name(&noisy, HYP_DISPATCH));
@@ -317,8 +263,6 @@ mod tests {
         let message = sample_message(7);
         let wire = message.to_vec();
         assert_eq!(wire.len(), ENCODED_MESSAGE_LEN);
-        // The wire form ends in 0x00 (zero body tail) and the payload pads
-        // with further zeros; only the exact 141-byte slice decodes right.
         assert_eq!(*wire.last().expect("non-empty"), 0);
 
         let event = misc_event(1, HYP_DISPATCH, &wire);
@@ -359,7 +303,6 @@ mod tests {
         assert_eq!(meta.address, address);
         assert_eq!(meta.block_number, event.block_height);
         assert_eq!(meta.block_hash, event.block_hash);
-        // H256 -> H512 widening is right-aligned, so it round-trips back.
         assert_eq!(meta.transaction_id, H512::from(event.tx_hash));
         assert_eq!(H256::from(meta.transaction_id), event.tx_hash);
         assert_eq!(meta.transaction_index, event.tx_id);
@@ -379,12 +322,9 @@ mod tests {
 
     #[test]
     fn tip_saturates_above_u32_max() {
-        // No block seen yet -> 0.
         assert_eq!(height_to_tip(None), 0);
-        // In-range height passes through unchanged.
         assert_eq!(height_to_tip(Some(12345)), 12345);
         assert_eq!(height_to_tip(Some(u32::MAX as u64)), u32::MAX);
-        // A height above u32::MAX saturates (does NOT wrap/truncate).
         assert_eq!(height_to_tip(Some(u32::MAX as u64 + 1)), u32::MAX);
         assert_eq!(height_to_tip(Some(u64::MAX)), u32::MAX);
     }

--- a/rust/main/chains/hyperlane-midnight/src/indexer.rs
+++ b/rust/main/chains/hyperlane-midnight/src/indexer.rs
@@ -1,27 +1,8 @@
-//! Dispatch and delivery indexers for the Midnight Mailbox (#95).
+//! Dispatch and delivery indexers for the Midnight Mailbox.
 //!
-//! Both indexers replay the WarpRoute contract's `HYP_*` Misc events served
-//! by the Midnight indexer's `contractEvents` query, over BLOCK ranges — the
-//! same shape as the EVM event indexers (`IndexMode::Block` + block-range
-//! `fetch_logs_in_range`):
-//!
-//!   - [`MidnightDispatchIndexer`] decodes `HYP_DISPATCH` payloads (the
-//!     141-byte `HyperlaneMessage` wire form) into dispatched messages;
-//!     `Indexed.sequence` is the nonce decoded from the message, and the
-//!     sequence-aware cursor validates nonce contiguity across block ranges.
-//!     `latest_sequence_count_and_tip` stays a cheap state read of the
-//!     Mailbox `nonce` counter.
-//!   - [`MidnightDeliveryIndexer`] decodes `HYP_PROCESS` payloads (the
-//!     delivered message id) honoring the requested block range. Deliveries
-//!     have no sequence, so `latest_sequence_count_and_tip` is `(None, tip)`
-//!     and the framework drives it with the rate-limited (watermark) cursor,
-//!     exactly like EVM deliveries.
-//!
-//! Each event carries its transaction + block metadata, so the emitted
-//! [`LogMeta`] is real: block number/hash, tx hash (widened to `H512`), the
-//! indexer-global tx id as the transaction index, and the chain-global event
-//! id as the log index. This is what lets the scraper store Midnight logs
-//! (it drops zero-tx-hash logs).
+//! Both replay the WarpRoute contract's `HYP_*` events over block ranges, the
+//! same shape as the EVM event indexers. Dispatches carry the message nonce as
+//! their sequence; deliveries have none and run off the watermark cursor.
 
 use std::ops::RangeInclusive;
 
@@ -39,13 +20,10 @@ use crate::events::{
 use crate::indexer_client::MiscEvent;
 use crate::MidnightIndexerClient;
 
-/// Indexer that serves dispatched `HyperlaneMessage`s from the Midnight
-/// Mailbox's `HYP_DISPATCH` events.
+/// Serves dispatched messages from the Mailbox's `HYP_DISPATCH` events.
 #[derive(Debug, Clone)]
 pub struct MidnightDispatchIndexer {
     client: MidnightIndexerClient,
-    /// WarpRoute (Mailbox) contract address; both the GraphQL event-filter key
-    /// and the `LogMeta.address` reported for every dispatched message.
     address: H256,
 }
 
@@ -59,11 +37,8 @@ impl MidnightDispatchIndexer {
     }
 }
 
-/// Decode the `HYP_DISPATCH` events out of a Misc-event batch. Non-dispatch
-/// events (gas payments from a shared-contract deployment, future kinds) are
-/// skipped; a dispatch event that fails to decode is an error, not a skip —
-/// a malformed dispatch would otherwise silently create a nonce gap that
-/// stalls the sequence-aware cursor with no diagnostic.
+/// A dispatch that fails to decode is an error rather than a skip: skipping it
+/// would leave a nonce gap that stalls the cursor with no diagnostic.
 fn dispatch_logs_from_events(
     events: &[MiscEvent],
     address: H256,
@@ -73,16 +48,14 @@ fn dispatch_logs_from_events(
         .filter(|event| has_name(event, HYP_DISPATCH))
         .map(|event| {
             let message = decode_dispatch_event(event)?;
-            // `Indexed::from(HyperlaneMessage)` sets `sequence` to the message
-            // nonce, which is exactly the dispatch sequence the cursor keys on.
+            // `Indexed::from` sets `sequence` to the message nonce, which is
+            // the dispatch sequence the cursor keys on.
             Ok((Indexed::from(message), event_log_meta(event, address)))
         })
         .collect()
 }
 
-/// Serve a block `range` of dispatches. Generic over the event reader so unit
-/// tests can drive the indexer logic with synthetic in-memory events;
-/// production uses [`MidnightIndexerClient`].
+/// Generic over the event reader so unit tests can drive this without network IO.
 async fn fetch_dispatch_logs<R: MidnightEventReader>(
     reader: &R,
     address: H256,
@@ -94,9 +67,6 @@ async fn fetch_dispatch_logs<R: MidnightEventReader>(
     dispatch_logs_from_events(&events, address)
 }
 
-/// Serve the dispatches emitted by one transaction. The framework hands an
-/// `H512`; a hash whose upper half is non-zero cannot be a Midnight tx hash,
-/// so it matches nothing.
 async fn fetch_dispatch_logs_by_tx<R: MidnightEventReader>(
     reader: &R,
     address: H256,
@@ -135,9 +105,7 @@ impl Indexer<HyperlaneMessage> for MidnightDispatchIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<HyperlaneMessage> for MidnightDispatchIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        // The Mailbox `nonce` counter is the dispatch count — a cheap state
-        // read (one fetch, one counter decode), kept alongside the
-        // event-based log fetch the way EVM reads `mailbox.nonce()`.
+        // The Mailbox `nonce` counter is the dispatch count.
         let tip = self.client.read_tip().await?;
         let count = self
             .client
@@ -147,13 +115,10 @@ impl SequenceAwareIndexer<HyperlaneMessage> for MidnightDispatchIndexer {
     }
 }
 
-/// Indexer that serves delivered message ids from the Midnight Mailbox's
-/// `HYP_PROCESS` events.
+/// Serves delivered message ids from the Mailbox's `HYP_PROCESS` events.
 #[derive(Debug, Clone)]
 pub struct MidnightDeliveryIndexer {
     client: MidnightIndexerClient,
-    /// WarpRoute (Mailbox) contract address; both the GraphQL event-filter key
-    /// and the `LogMeta.address` reported for every delivery.
     address: H256,
 }
 
@@ -167,8 +132,6 @@ impl MidnightDeliveryIndexer {
     }
 }
 
-/// Decode the `HYP_PROCESS` events out of a Misc-event batch. Deliveries
-/// carry no sequence (`Indexed::new`), matching EVM.
 fn delivery_logs_from_events(
     events: &[MiscEvent],
     address: H256,
@@ -183,8 +146,6 @@ fn delivery_logs_from_events(
         .collect()
 }
 
-/// Serve a block `range` of deliveries. Generic over the event reader for the
-/// same unit-test reason as [`fetch_dispatch_logs`].
 async fn fetch_delivery_logs<R: MidnightEventReader>(
     reader: &R,
     address: H256,
@@ -202,8 +163,6 @@ impl Indexer<H256> for MidnightDeliveryIndexer {
         &self,
         range: RangeInclusive<u32>,
     ) -> ChainResult<Vec<(Indexed<H256>, LogMeta)>> {
-        // The rate-limited (watermark) cursor walks block ranges and expects
-        // the fetch to honor them; the `fromBlock`/`toBlock` filter does.
         fetch_delivery_logs(&self.client, self.address, range).await
     }
 
@@ -229,8 +188,6 @@ impl Indexer<H256> for MidnightDeliveryIndexer {
 #[async_trait]
 impl SequenceAwareIndexer<H256> for MidnightDeliveryIndexer {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        // Deliveries have no sequence; `(None, tip)` matches the EVM mailbox
-        // delivery indexer and keeps the watermark cursor model.
         let tip = self.client.read_tip().await?;
         Ok((None, tip))
     }
@@ -256,9 +213,6 @@ mod tests {
             sender: H256::repeat_byte(0xAA),
             destination: 2,
             recipient: H256::repeat_byte(0xBB),
-            // The contract's wire form is a fixed Bytes<141>, i.e. a 64-byte
-            // body. The zero tail also pins the fixed-offset payload slicing
-            // (the padding past 141 is not part of the message).
             body: {
                 let mut b = vec![0u8; 64];
                 b[0] = nonce as u8;
@@ -267,7 +221,6 @@ mod tests {
         }
     }
 
-    /// A dispatch event at block `1000 + id` (see `misc_event`).
     fn dispatch_event(id: u64, nonce: u32) -> MiscEvent {
         misc_event(id, HYP_DISPATCH, &message(nonce).to_vec())
     }
@@ -278,7 +231,6 @@ mod tests {
             tip: TIP,
             events: vec![
                 dispatch_event(1, 0),
-                // Foreign event kind interleaved in the same range: skipped.
                 misc_event(2, HYP_GAS_PAYMENT, &[0u8; 60]),
                 dispatch_event(3, 1),
             ],
@@ -298,20 +250,18 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_honors_block_range() {
-        // Events sit at blocks 1001 and 1003 (misc_event: 1000 + id).
+        // These sit at blocks 1001 and 1003.
         let reader = FakeEventReader {
             tip: TIP,
             events: vec![dispatch_event(1, 0), dispatch_event(3, 1)],
         };
 
-        // A range covering only the first block yields only the first event.
         let logs = fetch_dispatch_logs(&reader, ADDRESS, 1000..=1002)
             .await
             .expect("fetch dispatch logs");
         assert_eq!(logs.len(), 1);
         assert_eq!(logs[0].0.sequence, Some(0));
 
-        // A disjoint range yields nothing.
         let logs = fetch_dispatch_logs(&reader, ADDRESS, 1004..=1100)
             .await
             .expect("fetch dispatch logs");
@@ -335,7 +285,6 @@ mod tests {
         assert_eq!(meta.address, ADDRESS);
         assert_eq!(meta.block_number, event.block_height);
         assert_eq!(meta.block_hash, event.block_hash);
-        // Real tx hash, H256 -> H512 right-aligned widening.
         assert_eq!(meta.transaction_id, H512::from(event.tx_hash));
         assert_eq!(meta.transaction_index, event.tx_id);
         assert_eq!(meta.log_index, U256::from(event.id));
@@ -350,7 +299,6 @@ mod tests {
             events: vec![wanted.clone(), other],
         };
 
-        // The transactionHash filter narrows to the one emitting tx.
         let logs = fetch_dispatch_logs_by_tx(&reader, ADDRESS, wanted.tx_hash.into())
             .await
             .expect("fetch by tx hash");
@@ -358,7 +306,6 @@ mod tests {
         assert_eq!(logs[0].0.sequence, Some(0));
         assert_eq!(logs[0].1.transaction_id, H512::from(wanted.tx_hash));
 
-        // A non-Midnight H512 (non-zero upper half) matches nothing.
         let mut foreign: H512 = wanted.tx_hash.into();
         foreign.0[0] = 1;
         let logs = fetch_dispatch_logs_by_tx(&reader, ADDRESS, foreign)
@@ -369,9 +316,8 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_dispatch_event_is_an_error_not_a_gap() {
-        // A HYP_DISPATCH payload that is NOT a decodable message (wrong
-        // version byte is fine — read_from doesn't validate version; instead
-        // give it a short payload) must fail the whole fetch loudly.
+        // A short payload, since `read_from` does not validate the version
+        // byte. It must fail the whole fetch rather than skip the event.
         let mut bad = misc_event(1, HYP_DISPATCH, &[0xFFu8; 16]);
         bad.payload.truncate(16);
         let err = dispatch_logs_from_events(&[bad], ADDRESS);
@@ -386,7 +332,6 @@ mod tests {
             tip: TIP,
             events: vec![
                 misc_event(1, HYP_PROCESS, id_a.as_bytes()),
-                // A dispatch in the same range is not a delivery.
                 dispatch_event(2, 0),
                 misc_event(3, HYP_PROCESS, id_b.as_bytes()),
             ],
@@ -399,13 +344,10 @@ mod tests {
         assert_eq!(logs.len(), 2);
         assert_eq!(*logs[0].0.inner(), id_a);
         assert_eq!(*logs[1].0.inner(), id_b);
-        // Deliveries have no sequence (EVM parity).
         assert!(logs.iter().all(|(indexed, _)| indexed.sequence.is_none()));
-        // Real per-event meta.
         assert_eq!(logs[0].1.block_number, 1001);
         assert_eq!(logs[1].1.block_number, 1003);
 
-        // The range is honored: a window over only the second delivery.
         let logs = fetch_delivery_logs(&reader, ADDRESS, 1003..=1003)
             .await
             .expect("fetch delivery logs");

--- a/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
+++ b/rust/main/chains/hyperlane-midnight/src/indexer_client.rs
@@ -12,52 +12,35 @@ use hyperlane_core::H256;
 use crate::state_decode::{decode_ism_state, decode_nonce_count, IsmState};
 use crate::HyperlaneMidnightError;
 
-/// How long a decoded ISM state is reused before re-reading from the indexer.
-/// Short on purpose: it collapses the per-delivery read burst (the Mailbox
-/// re-reads the validator set to sort signatures on every `process`) while
-/// staying well under the relayer's 120s ISM cache, so an on-chain validator
-/// rotation is still picked up quickly.
+/// How long a decoded ISM state is reused before re-reading. Short on purpose:
+/// long enough to collapse the per-delivery read burst, short enough that an
+/// on-chain validator rotation is still picked up quickly.
 const ISM_STATE_TTL: Duration = Duration::from_secs(5);
 
-/// Page size for paginated `contractEvents` queries. The indexer orders
-/// results by the monotonic event `id`, so `limit`/`offset` paging over the
-/// append-only event log is stable; a page shorter than this marks the end.
+/// The indexer orders by the monotonic event `id`, so offset paging over the
+/// append-only log is stable and a short page marks the end.
 const CONTRACT_EVENTS_PAGE_SIZE: usize = 200;
 
-/// Fixed width of a Misc event name (Compact `Bytes<32>`), zero-padded by the
-/// indexer before serving.
+/// Compact `Bytes<32>`, zero-padded by the indexer before serving.
 pub const MISC_NAME_LEN: usize = 32;
 
-/// Fixed width of a Misc event payload (Compact `Bytes<256>`), zero-padded by
-/// the indexer before serving — consumers slice fixed offsets directly.
+/// Compact `Bytes<256>`, zero-padded by the indexer before serving.
 pub const MISC_PAYLOAD_LEN: usize = 256;
 
-/// The application status of the transaction an event was emitted from, as
-/// reported by the indexer's `transactionResult.status`.
+/// From the indexer's `transactionResult.status`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TxStatus {
-    /// Every segment of the transaction applied.
     Success,
-    /// Some segments applied, some failed.
     PartialSuccess,
-    /// Nothing applied.
     Failure,
 }
 
 impl TxStatus {
-    /// Whether events from a transaction with this status should be served to
-    /// the Hyperlane indexers. This is THE single place that decision lives.
-    ///
     /// A failed section drops every effect it produced, events included, and a
-    /// transcript only splits across sections at a `kernel.checkpoint()`, which
-    /// the Hyperlane contracts never emit. An event and the state write it
-    /// reports therefore commit or vanish together.
-    ///
-    /// - `Success` and `PartialSuccess`: any served event's paired state
-    ///   write is applied — index it.
-    /// - `Failure`: yields no events at all in the ledger; kept excluded as
-    ///   pure defence in depth.
+    /// transcript only splits at a `kernel.checkpoint()`, which the Hyperlane
+    /// contracts never emit. So an event and the state write it reports always
+    /// commit or vanish together, which makes `PartialSuccess` safe to index.
     pub fn is_indexable(self) -> bool {
         match self {
             TxStatus::Success | TxStatus::PartialSuccess => true,
@@ -66,54 +49,37 @@ impl TxStatus {
     }
 }
 
-/// A decoded `MiscContractEvent` (a Compact `emit` from a contract call),
-/// together with the transaction/block metadata the Hyperlane `LogMeta`
-/// needs. Only events whose transaction status is indexable (see
-/// [`TxStatus::is_indexable`]) are surfaced by the client.
+/// A Compact `emit` from a contract call, with the metadata a `LogMeta` needs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MiscEvent {
-    /// Contract-defined event name, zero-padded to 32 bytes (e.g.
-    /// `HYP_DISPATCH`).
     pub name: [u8; MISC_NAME_LEN],
-    /// Opaque zero-padded payload, always [`MISC_PAYLOAD_LEN`] bytes;
-    /// consumers slice fixed offsets.
+    /// Always [`MISC_PAYLOAD_LEN`] bytes; consumers slice fixed offsets.
     pub payload: Vec<u8>,
-    /// Chain-global monotonic event id. SPARSE per contract: other event
+    /// Chain-global monotonic event id. Sparse per contract, since other event
     /// kinds share the sequence, so never assume contiguity.
     pub id: u64,
-    /// Hash of the transaction the event was emitted from.
     pub tx_hash: H256,
     /// Indexer-global transaction id (a monotonic integer, not per-block).
     pub tx_id: u64,
-    /// Hash of the block containing the transaction.
     pub block_hash: H256,
-    /// Height of the block containing the transaction.
     pub block_height: u64,
     /// Block timestamp in unix milliseconds.
     pub block_timestamp_ms: u64,
-    /// The transaction's application status.
     pub tx_status: TxStatus,
 }
 
-/// Block metadata from `Query.block`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockDetails {
-    /// Block hash.
     pub hash: H256,
-    /// Block height.
     pub height: u64,
     /// Block timestamp in unix milliseconds (Substrate `Timestamp::set`).
     pub timestamp_ms: u64,
 }
 
-/// Transaction metadata from `Query.transactions`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionDetails {
-    /// Transaction hash.
     pub hash: H256,
-    /// Indexer-global transaction id.
     pub id: u64,
-    /// The block containing the transaction.
     pub block: BlockDetails,
     /// Application status; `None` for transaction kinds that carry no
     /// `transactionResult` (system transactions).
@@ -123,11 +89,9 @@ pub struct TransactionDetails {
     pub fee_specks: Option<hyperlane_core::U256>,
 }
 
-/// GraphQL selection for `contractEvents`. The filter always narrows to
-/// `types: [MISC]`, so every element is a `MiscContractEvent`; `name`/
-/// `payload` live behind the inline fragment because they are not on the
-/// `ContractEvent` interface, and `transactionResult` needs the
-/// `RegularTransaction` fragment (system transactions carry no result).
+/// GraphQL selection for `contractEvents`. `name`/`payload` sit behind an
+/// inline fragment because they are not on the `ContractEvent` interface, and
+/// `transactionResult` only exists on `RegularTransaction`.
 const CONTRACT_EVENTS_QUERY: &str = r#"query ($filter: ContractEventFilter!, $limit: Int!, $offset: Int!) {
   contractEvents(filter: $filter, limit: $limit, offset: $offset) {
     __typename
@@ -147,11 +111,9 @@ const CONTRACT_EVENTS_QUERY: &str = r#"query ($filter: ContractEventFilter!, $li
 pub struct MidnightIndexerClient {
     endpoint: Url,
     http: reqwest::Client,
-    /// Per-address cache of the decoded ISM state, shared across clones of
-    /// this client (it is cloned into the provider). Caches successful decodes
-    /// only. Note: the Mailbox and the ISM build separate client instances, so
-    /// they do not share this cache with each other — it removes the
-    /// per-delivery re-read within a single long-lived client.
+    /// Per-address cache of successfully decoded ISM state, shared across
+    /// clones of this client. The Mailbox and the ISM build separate clients,
+    /// so each caches its own reads.
     ism_cache: Arc<Mutex<HashMap<String, (IsmState, Instant)>>>,
 }
 
@@ -177,14 +139,8 @@ impl MidnightIndexerClient {
         Ok(data.and_then(|d| d.block.map(|b| b.height)))
     }
 
-    /// Fetch the full serialized ledger state of a deployed contract at the
-    /// indexer's latest observed block, hex-decoded into raw bytes. This is a
-    /// one-shot `contractAction(address)` HTTP query returning the latest
-    /// state, not the streaming `contractActions` subscription. No `offset` is
-    /// passed, so the read is not pinned to a fixed block; the schema's
-    /// `offset: ContractActionOffset` supports block-pinned reads if a future
-    /// caller needs them. `address` is the contract address as the indexer's
-    /// `HexEncoded` scalar (hex, with or without `0x`).
+    /// The full serialized ledger state at the indexer's latest observed block.
+    /// No `offset` is passed, so the read is not pinned to a block.
     pub async fn contract_state(&self, address: &str) -> Result<Vec<u8>, HyperlaneMidnightError> {
         let query =
             r#"query ($address: HexEncoded!) { contractAction(address: $address) { state } }"#;
@@ -207,10 +163,9 @@ impl MidnightIndexerClient {
         })
     }
 
-    /// Read and decode the MessageIdMultisigIsm config (validators, threshold,
-    /// module type) from the deployed `night` contract's on-chain state.
-    /// Cached for `ISM_STATE_TTL` to avoid a fresh network read + decode on
-    /// every Mailbox delivery.
+    /// Read and decode the MessageIdMultisigIsm config from the deployed
+    /// contract's state. Cached for `ISM_STATE_TTL` so a Mailbox delivery does
+    /// not pay for a fresh read and decode.
     pub async fn read_ism_state(&self, address: &str) -> ChainResult<IsmState> {
         if let Ok(cache) = self.ism_cache.lock() {
             if let Some((state, fetched_at)) = cache.get(address) {
@@ -228,19 +183,15 @@ impl MidnightIndexerClient {
         Ok(state)
     }
 
-    /// Read the Mailbox `nonce` counter (the number of messages dispatched so
-    /// far) from the deployed `night` contract's state. The dispatch and
-    /// merkle indexers use this as the sequence tip — a single state fetch
-    /// plus a one-counter decode, no per-message decoding.
+    /// The dispatch and merkle indexers use this as their sequence tip: one
+    /// state fetch and one counter decode, with no per-message work.
     pub async fn read_nonce_count(&self, address: &str) -> ChainResult<u32> {
         let bytes = self.contract_state(address).await?;
         decode_nonce_count(&bytes)
     }
 
-    /// Fetch every Misc contract event `address` emitted in the inclusive
-    /// block range, in monotonic event-id order, paginated transparently.
-    /// Events from `FAILURE` transactions are excluded (see
-    /// [`TxStatus::is_indexable`]).
+    /// In event-id order, paginated transparently, with failed transactions
+    /// excluded (see [`TxStatus::is_indexable`]).
     pub async fn misc_events_in_range(
         &self,
         address: &str,
@@ -256,9 +207,7 @@ impl MidnightIndexerClient {
         self.misc_events_filtered(filter).await
     }
 
-    /// Fetch every Misc contract event `address` emitted from the transaction
-    /// with the given hash (the `transactionHash` filter). Events from
-    /// `FAILURE` transactions are excluded (see [`TxStatus::is_indexable`]).
+    /// Failed transactions are excluded (see [`TxStatus::is_indexable`]).
     pub async fn misc_events_by_tx_hash(
         &self,
         address: &str,
@@ -272,8 +221,6 @@ impl MidnightIndexerClient {
         self.misc_events_filtered(filter).await
     }
 
-    /// Run the paginated `contractEvents` query for the given filter, looping
-    /// pages until a short page marks the end of the result set.
     async fn misc_events_filtered(
         &self,
         filter: serde_json::Value,
@@ -419,8 +366,6 @@ struct GraphqlResponse<T> {
 }
 
 impl<T> GraphqlResponse<T> {
-    /// Surface any GraphQL-level errors as a single error, otherwise yield the
-    /// `data` payload. Keeps error handling in one place for every query.
     fn into_data(self) -> Result<Option<T>, HyperlaneMidnightError> {
         if let Some(errors) = self.errors {
             if !errors.is_empty() {
@@ -530,14 +475,12 @@ struct TransactionsData {
     transactions: Vec<RawTransaction>,
 }
 
-/// Decode a `HexEncoded` scalar (with or without `0x`) into raw bytes.
 fn hex_bytes(value: &str, what: &str) -> Result<Vec<u8>, HyperlaneMidnightError> {
     hex::decode(value.trim_start_matches("0x")).map_err(|e| {
         HyperlaneMidnightError::IndexerGraphql(format!("{what} is not valid hex: {e}"))
     })
 }
 
-/// Decode a `HexEncoded` scalar into an exact 32-byte hash.
 fn hex_h256(value: &str, what: &str) -> Result<H256, HyperlaneMidnightError> {
     let bytes = hex_bytes(value, what)?;
     if bytes.len() != 32 {
@@ -549,9 +492,8 @@ fn hex_h256(value: &str, what: &str) -> Result<H256, HyperlaneMidnightError> {
     Ok(H256::from_slice(&bytes))
 }
 
-/// Decode a `HexEncoded` scalar into a fixed-width buffer, right-padding with
-/// zeros. The indexer already re-pads Misc names/payloads to their declared
-/// widths, so the pad is defensive; only an over-long value is an error.
+/// The indexer already re-pads names and payloads to their declared widths, so
+/// the padding here is belt-and-braces; only an over-long value is an error.
 fn hex_padded(value: &str, width: usize, what: &str) -> Result<Vec<u8>, HyperlaneMidnightError> {
     let mut bytes = hex_bytes(value, what)?;
     if bytes.len() > width {
@@ -597,19 +539,14 @@ impl RawTransaction {
     }
 }
 
-/// Convert raw `contractEvents` rows into [`MiscEvent`]s, applying the
-/// status filter ([`TxStatus::is_indexable`]). Rows that are not
-/// `MiscContractEvent` are skipped defensively — the filter always narrows to
-/// `types: [MISC]`, so none are expected. A transaction kind without a
-/// `transactionResult` cannot be a contract call, so such rows are skipped
-/// too (contract events only come from `RegularTransaction`s).
+/// Rows that are not `MiscContractEvent`, or that carry no `transactionResult`
+/// and so cannot be a contract call, are skipped.
 fn misc_events_from_raw(
     raw: Vec<RawContractEvent>,
 ) -> Result<Vec<MiscEvent>, HyperlaneMidnightError> {
     let mut out = Vec::with_capacity(raw.len());
     for event in raw {
         let (Some(name), Some(payload)) = (event.name.as_deref(), event.payload.as_deref()) else {
-            // Not a MiscContractEvent (no inline-fragment fields).
             if event.typename == "MiscContractEvent" {
                 return Err(HyperlaneMidnightError::IndexerGraphql(format!(
                     "MiscContractEvent {} is missing name/payload",
@@ -621,7 +558,6 @@ fn misc_events_from_raw(
         let Some(result) = &event.transaction.transaction_result else {
             continue;
         };
-        // THE status decision lives in `TxStatus::is_indexable`.
         if !result.status.is_indexable() {
             continue;
         }
@@ -648,13 +584,8 @@ fn misc_events_from_raw(
 mod tests {
     use super::*;
 
-    /// Parse the committed `contractEvents` GraphQL response fixture through
-    /// the exact serde structs + conversion the client uses. The fixture has
-    /// five Misc events: two SUCCESS dispatches, a SUCCESS gas payment, a
-    /// PARTIAL_SUCCESS dispatch, and a FAILURE dispatch — so it pins the
-    /// status filter (FAILURE dropped, PARTIAL_SUCCESS kept for now), the
-    /// zero-padded name/payload widths, `0x`-prefixed and bare hex hashes,
-    /// and the tx/block metadata mapping.
+    /// The fixture carries one event of every status, so it pins the filter,
+    /// the padded widths, both hash spellings, and the metadata mapping.
     #[test]
     fn parses_contract_events_fixture() {
         let response: GraphqlResponse<ContractEventsData> = serde_json::from_str(include_str!(
@@ -669,7 +600,6 @@ mod tests {
         assert_eq!(raw.len(), 5, "fixture has five raw events");
 
         let events = misc_events_from_raw(raw).expect("convert events");
-        // The FAILURE event (id 27) is dropped; PARTIAL_SUCCESS (id 19) kept.
         assert_eq!(events.len(), 4, "FAILURE event is excluded");
         assert_eq!(
             events.iter().map(|e| e.id).collect::<Vec<_>>(),
@@ -689,7 +619,6 @@ mod tests {
         assert_eq!(dispatch.block_timestamp_ms, 1_700_000_000_000);
         assert_eq!(dispatch.tx_status, TxStatus::Success);
 
-        // The PARTIAL_SUCCESS dispatch is included (see TxStatus::is_indexable).
         assert_eq!(events[2].tx_status, TxStatus::PartialSuccess);
 
         // The HYP_PROCESS event's hashes are 0x-prefixed in the fixture.
@@ -699,25 +628,21 @@ mod tests {
     }
 
     #[test]
-    fn tx_status_filter_is_the_single_decision_point() {
+    fn tx_status_filter_excludes_only_failures() {
         assert!(TxStatus::Success.is_indexable());
-        // PARTIAL_SUCCESS is included FOR NOW; segment attribution is being
-        // verified separately (devnet probe). Flip in `is_indexable`.
         assert!(TxStatus::PartialSuccess.is_indexable());
         assert!(!TxStatus::Failure.is_indexable());
     }
 
     #[test]
     fn hex_padded_pads_short_and_rejects_long() {
-        // Short values right-pad with zeros (defensive; the indexer re-pads).
         let padded = hex_padded("aabb", 4, "test").expect("pad");
         assert_eq!(padded, vec![0xaa, 0xbb, 0x00, 0x00]);
         // Over-long values are an error, not a truncation.
         assert!(hex_padded("aabbccddee", 4, "test").is_err());
     }
 
-    /// Parse a `transactions(offset: {hash})` response, including the
-    /// RegularTransaction-only `transactionResult` + `fee` fields.
+    /// Covers the `RegularTransaction`-only `transactionResult` and `fee`.
     #[test]
     fn parses_transaction_details() {
         let json = r#"{
@@ -749,11 +674,8 @@ mod tests {
         assert_eq!(details.fee_specks, Some(hyperlane_core::U256::from(123456)));
     }
 
-    /// Live integration test: read the deployed `night` contract's ISM state
-    /// from a running Midnight indexer and assert it decodes to a valid,
-    /// internally-consistent MessageIdMultisig config — i.e. the live
-    /// `contractAction` query + native decode work end-to-end against a real
-    /// standalone node. Ignored by default; run with the devnet up:
+    /// Live check that the `contractAction` query and the native decode work
+    /// end to end. Run with the devnet up:
     ///
     ///   MIDNIGHT_INDEXER_URL=http://127.0.0.1:8088/api/v3/graphql \
     ///   MIDNIGHT_NIGHT_ADDRESS=<deployed night address hex> \
@@ -774,18 +696,15 @@ mod tests {
 
         println!("decoded ISM state from chain: {ism:?}");
 
-        // MessageIdMultisig is discriminant 5 in Hyperlane's ModuleType enum.
         assert_eq!(
             ism.module_type, 5,
             "module_type should be MessageIdMultisig"
         );
-        // Decoded slot count must match the validators map.
         assert_eq!(
             ism.validator_count as usize,
             ism.validators.len(),
             "validator_count must match decoded validator slots"
         );
-        // A usable multisig: >= 1 validator and 1 <= threshold <= count.
         assert!(
             !ism.validators.is_empty(),
             "expected at least one validator"

--- a/rust/main/chains/hyperlane-midnight/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-midnight/src/interchain_gas.rs
@@ -1,30 +1,8 @@
-//! `InterchainGasPaymaster` + IGP payment indexer for Midnight (#95).
+//! `InterchainGasPaymaster` + IGP payment indexer for Midnight.
 //!
-//! The IGP contract emits one `HYP_GAS_PAYMENT` Misc event per `payForGas`,
-//! atomically with the state write. This indexer replays those events over
-//! BLOCK ranges through the Midnight indexer's `contractEvents` query —
-//! matching the EVM IGP indexer exactly:
-//!
-//!   - gas payments are NOT sequence-indexed: `Indexed::new(payment)` carries
-//!     no sequence and `latest_sequence_count_and_tip` returns `(None, tip)`,
-//!     so the framework drives this indexer with the rate-limited (watermark)
-//!     cursor, the same as EVM (`Indexable for InterchainGasPayment`).
-//!   - each event carries its transaction + block metadata, so the emitted
-//!     [`LogMeta`] is real (block number/hash, tx hash, indexer-global tx id,
-//!     chain-global event id).
-//!
-//! Following Aleo/Radix/CosmosNative, one struct serves both roles the
-//! framework builds: the [`InterchainGasPaymaster`] marker (a boxed trait
-//! object every configured chain must provide, though the relayer never calls
-//! it) and the indexer that actually feeds payments into the relayer's DB.
-//!
-//! The relayer's gas-payment *enforcement* (the None / Minimum /
-//! OnChainFeeQuoting policies + matching lists) is entirely chain-agnostic and
-//! lives in `agents/relayer/src/msg/gas_payment/`: it reads the
-//! `InterchainGasPayment`s this indexer wrote into RocksDB and never touches
-//! the chain crate. So this indexer only needs to produce the same
-//! `InterchainGasPayment` data the EVM event indexer produces — the policies
-//! work unchanged.
+//! The IGP emits one `HYP_GAS_PAYMENT` event per `payForGas`, atomically with
+//! the state write, and this replays them over block ranges. Payments carry no
+//! sequence, so the watermark cursor drives it.
 
 use std::ops::RangeInclusive;
 
@@ -43,11 +21,7 @@ use crate::events::{
 use crate::indexer_client::MiscEvent;
 use crate::MidnightProvider;
 
-/// Decode the `HYP_GAS_PAYMENT` events out of a Misc-event batch. Non-payment
-/// events (dispatches from a shared-contract deployment, future kinds) are
-/// skipped; a payment event that fails to decode is an error, not a skip.
-/// No sequence is attached — gas payments are not sequence-indexed (EVM
-/// parity; the watermark cursor tracks progress by block, not sequence).
+/// A payment that fails to decode is an error rather than a skip.
 fn igp_logs_from_events(
     events: &[MiscEvent],
     address: H256,
@@ -62,9 +36,7 @@ fn igp_logs_from_events(
         .collect()
 }
 
-/// Serve a block `range` of gas payments. Generic over the event reader so
-/// unit tests can drive the indexer logic with synthetic in-memory events;
-/// production uses the provider's [`crate::MidnightIndexerClient`].
+/// Generic over the event reader so unit tests can drive this without network IO.
 async fn fetch_igp_logs<R: MidnightEventReader>(
     reader: &R,
     address: H256,
@@ -76,8 +48,6 @@ async fn fetch_igp_logs<R: MidnightEventReader>(
     igp_logs_from_events(&events, address)
 }
 
-/// Serve the gas payments emitted by one transaction (the `transactionHash`
-/// filter); the relayer broadcasts dispatch txids to the IGP sync task.
 async fn fetch_igp_logs_by_tx<R: MidnightEventReader>(
     reader: &R,
     address: H256,
@@ -92,9 +62,7 @@ async fn fetch_igp_logs_by_tx<R: MidnightEventReader>(
     igp_logs_from_events(&events, address)
 }
 
-/// Chain-sourced `InterchainGasPaymaster` + IGP payment indexer for Midnight.
-/// Replays the IGP contract's `HYP_GAS_PAYMENT` events via the Midnight
-/// indexer's `contractEvents` query.
+/// `InterchainGasPaymaster` + IGP payment indexer for Midnight.
 #[derive(Debug, Clone)]
 pub struct MidnightInterchainGasPaymaster {
     address: H256,
@@ -133,9 +101,6 @@ impl InterchainGasPaymaster for MidnightInterchainGasPaymaster {}
 
 #[async_trait]
 impl Indexer<InterchainGasPayment> for MidnightInterchainGasPaymaster {
-    /// Midnight indexes gas payments over block ranges (`IndexMode::Block` +
-    /// the rate-limited cursor, EVM parity), so `range` is a block range and
-    /// the `fromBlock`/`toBlock` event filter honors it.
     async fn fetch_logs_in_range(
         &self,
         range: RangeInclusive<u32>,
@@ -144,9 +109,8 @@ impl Indexer<InterchainGasPayment> for MidnightInterchainGasPaymaster {
     }
 
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
-        // Midnight has BFT finality and the indexer exposes only finalized
-        // blocks, so the latest height is the finalized height. The watermark
-        // cursor reads this as its tip.
+        // Midnight has BFT finality and the indexer serves only finalized
+        // blocks, so the latest height is the finalized height.
         self.provider.indexer().read_tip().await
     }
 
@@ -161,8 +125,6 @@ impl Indexer<InterchainGasPayment> for MidnightInterchainGasPaymaster {
 #[async_trait]
 impl SequenceAwareIndexer<InterchainGasPayment> for MidnightInterchainGasPaymaster {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        // Gas payments are not sequence-indexed; `(None, tip)` matches the
-        // EVM IGP indexer (the rate-limited cursor never reads the count).
         let tip = self.provider.indexer().read_tip().await?;
         Ok((None, tip))
     }
@@ -180,8 +142,7 @@ mod tests {
     const ADDRESS: H256 = H256::repeat_byte(0x42);
     const TIP: u32 = 2000;
 
-    /// A `HYP_GAS_PAYMENT` event at block `1000 + id` (see `misc_event`),
-    /// with all four record fields derived from `seed`.
+    /// All four record fields are derived from `seed`.
     fn payment_event(id: u64, seed: u8) -> MiscEvent {
         let mut content = Vec::with_capacity(60);
         content.extend_from_slice(H256::repeat_byte(seed).as_bytes());
@@ -197,7 +158,6 @@ mod tests {
             tip: TIP,
             events: vec![
                 payment_event(1, 0),
-                // A dispatch interleaved in the same range: not a payment.
                 misc_event(2, HYP_DISPATCH, &[0u8; 141]),
                 payment_event(3, 7),
             ],
@@ -208,7 +168,6 @@ mod tests {
             .expect("fetch igp logs");
 
         assert_eq!(logs.len(), 2, "only HYP_GAS_PAYMENT events are served");
-        // EVM parity: no sequence on gas payments.
         assert!(logs.iter().all(|(indexed, _)| indexed.sequence.is_none()));
 
         let p = logs[1].0.inner();
@@ -220,7 +179,7 @@ mod tests {
 
     #[tokio::test]
     async fn honors_block_range() {
-        // Events sit at blocks 1001 and 1003 (misc_event: 1000 + id).
+        // These sit at blocks 1001 and 1003.
         let reader = FakeEventReader {
             tip: TIP,
             events: vec![payment_event(1, 0), payment_event(3, 1)],
@@ -270,7 +229,6 @@ mod tests {
         assert_eq!(logs.len(), 1);
         assert_eq!(logs[0].0.inner().message_id, H256::repeat_byte(0));
 
-        // A non-Midnight H512 (non-zero upper half) matches nothing.
         let mut foreign: H512 = wanted.tx_hash.into();
         foreign.0[0] = 1;
         let logs = fetch_igp_logs_by_tx(&reader, ADDRESS, foreign)

--- a/rust/main/chains/hyperlane-midnight/src/ism.rs
+++ b/rust/main/chains/hyperlane-midnight/src/ism.rs
@@ -1,15 +1,8 @@
 //! `InterchainSecurityModule` + `MultisigIsm` impls for Midnight.
 //!
-//! Both read from the deployed `night` contract's on-chain state via the
-//! indexer (a one-shot `contractAction` HTTP query returning the latest
-//! state), decoded by [`crate::state_decode`]. `validators`, `threshold`,
-//! and `module_type` all come from one such read, so the relayer always
-//! signs against the set the on-chain ISM will check — no config/chain drift.
-//!
-//! `module_type` is read from chain rather than hardcoded: the Midnight
-//! WarpRoute only implements `MessageIdMultisig` today, so any other value
-//! means the deployed contract uses verification logic this agent build
-//! does not support, and we error rather than guess.
+//! Validators, threshold, and module type all come from a single read of the
+//! deployed contract's state, so the relayer always signs against the set the
+//! on-chain ISM will check and nothing can drift out of config.
 
 use async_trait::async_trait;
 
@@ -20,10 +13,8 @@ use hyperlane_core::{
 
 use crate::{HyperlaneMidnightError, MidnightProvider};
 
-/// Map the on-chain `module_type` discriminant to a Hyperlane [`ModuleType`].
-/// The Midnight WarpRoute only implements `MessageIdMultisig`; any other
-/// value means the deployed contract uses verification logic this agent
-/// build does not support.
+/// The WarpRoute only implements `MessageIdMultisig`, so any other value means
+/// the deployed contract verifies in a way this build does not support.
 fn module_type_from_u8(value: u8) -> ChainResult<ModuleType> {
     if value == ModuleType::MessageIdMultisig as u8 {
         Ok(ModuleType::MessageIdMultisig)
@@ -36,8 +27,7 @@ fn module_type_from_u8(value: u8) -> ChainResult<ModuleType> {
     }
 }
 
-/// Chain-sourced `InterchainSecurityModule` for Midnight. Reads the module
-/// type from the deployed contract's on-chain state.
+/// `InterchainSecurityModule` for Midnight.
 #[derive(Debug)]
 pub struct MidnightInterchainSecurityModule {
     address: H256,
@@ -85,16 +75,14 @@ impl InterchainSecurityModule for MidnightInterchainSecurityModule {
         _message: &HyperlaneMessage,
         _metadata: &Metadata,
     ) -> ChainResult<Option<U256>> {
-        // Midnight uses DUST-based fees the wallet computes at submission
-        // time (same pattern as `MidnightMailbox::process_estimate_costs`).
-        // Returning `None` signals "I can't estimate" — the relayer falls
-        // back to its own logic without dry-running, which is fine.
+        // Fees are DUST the wallet computes at submission time, so there is
+        // nothing to estimate; `None` lets the relayer fall back to its own
+        // logic without dry-running.
         Ok(None)
     }
 }
 
-/// Chain-sourced `MultisigIsm` for Midnight. Reads validators + threshold
-/// from the deployed contract's on-chain state.
+/// `MultisigIsm` for Midnight.
 #[derive(Debug)]
 pub struct MidnightMultisigIsm {
     address: H256,
@@ -103,8 +91,8 @@ pub struct MidnightMultisigIsm {
 }
 
 impl MidnightMultisigIsm {
-    /// Construct an ISM handle. Validators + threshold are read from chain
-    /// state on each `validators_and_threshold` call, not from config.
+    /// Validators and threshold are read from chain state on each
+    /// `validators_and_threshold` call, not from config.
     pub fn new(address: H256, domain: HyperlaneDomain, provider: MidnightProvider) -> Self {
         Self {
             address,
@@ -138,13 +126,8 @@ impl MultisigIsm for MidnightMultisigIsm {
     ) -> ChainResult<(Vec<H256>, u8)> {
         let address = format!("{:x}", self.address);
         let state = self.provider.indexer().read_ism_state(&address).await?;
-        // On-chain validators are `Bytes<64>` secp256k1 pubkeys (#22); the
-        // state decoder derives each 20-byte ETH address as
-        // `keccak256(pubkey)[12..]`. The multisig metadata pipeline expects
-        // H256, so left-pad each with 12 zero bytes — Ethereum's standard
-        // `addressToBytes32` convention used elsewhere in the codebase.
-        // Validators and threshold come from the same single read, so they
-        // cannot drift apart.
+        // The metadata pipeline wants H256, so left-pad each address with 12
+        // zero bytes — the standard `addressToBytes32` convention.
         let padded: Vec<H256> = state
             .validators
             .iter()

--- a/rust/main/chains/hyperlane-midnight/src/lib.rs
+++ b/rust/main/chains/hyperlane-midnight/src/lib.rs
@@ -1,16 +1,8 @@
-//! Hyperlane Midnight chain integration.
+//! Implementation of hyperlane for Midnight.
 //!
-//! # Build feature
-//!
-//! This crate is an **optional** dependency of `hyperlane-base`, gated behind
-//! the `midnight` feature (off by default), mirroring how `hyperlane-aleo` is
-//! gated behind `aleo`. Agent binaries compile it -- and its heavy native
-//! decode stack (`midnight-onchain-*` and the transitive ZK proving crates
-//! `midnight-proofs` / `midnight-circuits` / `midnight-curves`) -- only when
-//! built with `--features midnight` (e.g. `cargo build -p relayer --features
-//! midnight`). A build without the feature drops the whole crate and that ZK
-//! dependency tree, and `is_protocol_supported` filters Midnight chains out of
-//! the agent config at parse time with an "enable with --features" warning.
+//! Gated behind the `midnight` feature (off by default) because the native
+//! state decode pulls in Midnight's ZK proving crates; without it, agents drop
+//! that dependency tree and filter Midnight chains out of their config.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/rust/main/chains/hyperlane-midnight/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-midnight/src/mailbox.rs
@@ -11,13 +11,10 @@ use hyperlane_core::{
 use crate::toolkit::{self, ToolkitContext, WireMetadata};
 use crate::{ConnectionConf, HyperlaneMidnightError, MidnightProvider};
 
-// Upper bound on how many validator signatures a metadata blob may carry,
-// matching the on-chain `MessageIdMultisigIsm.MAX_VALIDATORS` (#22 reduced this
-// from 16 to 4 to keep the handle proof tractable). The relayer forwards the
-// real, quorum-sized signature set (typically `threshold` entries) verbatim;
-// the Midnight submitter (`relayer/src/checkpoint-digest.ts`) is what pads the
-// on-chain `Vector<4, ...>` by repeating slot 0, so DO NOT pad here — a
-// zero-signature pad would recover to a garbage pubkey and be rejected.
+// Matches the contract's `MessageIdMultisigIsm.MAX_VALIDATORS`, kept small to
+// keep the handle proof tractable. Signatures are forwarded verbatim: the
+// submitter is what pads the on-chain `Vector<4>` by repeating slot 0, and a
+// zero-signature pad added here would recover to a garbage pubkey.
 const MAX_SIGNATURES: usize = 4;
 const SIGNATURE_LEN: usize = 65;
 const METADATA_HEADER_LEN: usize = 32 + 32 + 4;
@@ -29,9 +26,8 @@ pub struct MidnightMailbox {
     domain: HyperlaneDomain,
     provider: MidnightProvider,
     toolkit_ctx: ToolkitContext,
-    /// Test-only override for the on-chain validator order. Production reads
-    /// the set from chain state in [`Self::validator_order`]; tests set this
-    /// (to an empty vec) so `process` can run offline without an indexer.
+    /// Test-only override for the on-chain validator order, so `process` can
+    /// run offline without an indexer.
     #[cfg(test)]
     validator_override: Option<Vec<H160>>,
 }
@@ -52,8 +48,6 @@ impl MidnightMailbox {
         })
     }
 
-    /// Read the on-chain validator set (in slot order) from the deployed
-    /// contract, used to sort signatures by validator index before submitting.
     async fn validator_order(&self) -> ChainResult<Vec<H160>> {
         #[cfg(test)]
         if let Some(validators) = &self.validator_override {
@@ -122,14 +116,10 @@ impl Mailbox for MidnightMailbox {
     ) -> ChainResult<TxOutcome> {
         let mut parsed = parse_metadata(metadata.as_ref())?;
 
-        // The on-chain MessageIdMultisigIsm requires signatures in
-        // validator-set-index order (a two-pointer match). The relayer's
-        // metadata builder emits them in checkpoint-syncer fetch order, which
-        // only incidentally matches validator-index order within a single
-        // batch and is not guaranteed (only the Aleo destination gets an
-        // explicit ordering pass in `hyperlane-base/src/types/multisig.rs`).
-        // So read the on-chain validator set and sort here. An empty set means
-        // nothing to sort against (also the offline cross-boundary test path).
+        // The on-chain ISM matches signatures against the validator set with a
+        // forward-only walk, so they must arrive in set-index order. The
+        // relayer emits them in checkpoint-syncer fetch order, which only
+        // incidentally matches, so sort against the on-chain set here.
         let validators = self.validator_order().await?;
         if !validators.is_empty() {
             sort_signatures_by_validator_index(message, &mut parsed, &validators)?;
@@ -140,8 +130,7 @@ impl Mailbox for MidnightMailbox {
 
         let outcome = toolkit::submit_handle(&self.toolkit_ctx, &request).await?;
 
-        // Gas is the DUST actually paid, in specks, at a unit price; zero when
-        // the submitter did not report a fee.
+        // Gas is the DUST actually paid, in specks, at a unit price.
         Ok(TxOutcome {
             transaction_id: outcome.transaction_id,
             executed: outcome.executed,
@@ -156,21 +145,10 @@ impl Mailbox for MidnightMailbox {
         message: &HyperlaneMessage,
         metadata: &Metadata,
     ) -> ChainResult<TxCostEstimate> {
-        // Dry-run `handle` against current chain state (no proving, no
-        // submission). A message that would revert (unenrolled sender, amount
-        // over escrow, paused, replay, failed ISM, ...) returns `Err` here, so
-        // the relayer catches it at prepare time and applies the standard
-        // exponential backoff — rather than the revert only surfacing at submit
-        // time on the no-backoff `ErrorSubmitting` path, where it would
-        // busy-loop and starve every other inbound delivery (issue #80). This
-        // mirrors every other Hyperlane chain, whose `process_estimate_costs`
-        // simulates the call.
-        //
-        // Prepare the metadata exactly as `process` does (parse + sort by
-        // validator index + pad) so the dry-run executes what a real
-        // submission would — in particular the on-chain ISM's forward-only
-        // two-pointer walk requires signatures in validator-set order, so an
-        // unsorted vector would spuriously "revert".
+        // A message that would revert errors here, so the relayer backs off at
+        // prepare time instead of busy-looping on the no-backoff submit path.
+        // The metadata is prepared exactly as `process` prepares it, or an
+        // unsorted signature vector would revert spuriously.
         let mut parsed = parse_metadata(metadata.as_ref())?;
         let validators = self.validator_order().await?;
         if !validators.is_empty() {
@@ -180,10 +158,9 @@ impl Mailbox for MidnightMailbox {
             toolkit::build_dry_run_request(self.address, &self.toolkit_ctx, message, parsed, false);
         toolkit::dry_run_handle(&self.toolkit_ctx, &request).await?;
 
-        // The message would be accepted on-chain. Midnight fees are denominated
-        // in DUST and computed by the wallet at submission time, so there is no
-        // estimate to report. Zero mirrors Sealevel: it leaves
-        // `onChainFeeQuoting` permissive rather than imposing an arbitrary bar.
+        // Fees are DUST the wallet computes at submission time, so there is no
+        // estimate to report. Zero leaves `onChainFeeQuoting` permissive rather
+        // than imposing an arbitrary bar.
         Ok(TxCostEstimate {
             gas_limit: U256::zero(),
             gas_price: FixedPointNumber::zero(),
@@ -237,7 +214,7 @@ fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
     index_be.copy_from_slice(&bytes[64..68]);
     let index = u32::from_be_bytes(index_be);
 
-    let mut signatures: Vec<String> = (0..sig_count)
+    let signatures: Vec<String> = (0..sig_count)
         .map(|i| {
             let start = i * SIGNATURE_LEN;
             format!(
@@ -247,8 +224,6 @@ fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
         })
         .collect();
 
-    // No padding: forward exactly the real signatures the metadata carried.
-    // The Midnight submitter pads the on-chain `Vector<4>` by repeating slot 0.
     Ok(WireMetadata {
         merkle_tree_hook,
         root,
@@ -257,14 +232,9 @@ fn parse_metadata(bytes: &[u8]) -> ChainResult<WireMetadata> {
     })
 }
 
-/// Reorder the real signatures in `metadata` by their signer's index in
-/// `validators`. No padding is added — the Midnight submitter pads the
-/// on-chain `Vector<4>` by repeating slot 0.
-/// Errors if any signature recovers to an address not present in
-/// `validators` — that indicates either a malformed validator config or a
-/// genuinely invalid signature; either way the on-chain ISM would reject
-/// the call so failing fast here surfaces the issue with a clearer error
-/// than a Compact `assert` revert.
+/// Drops any zero padding. A signature recovering to an unknown address is an
+/// error: the on-chain ISM would reject the call anyway, and failing here gives
+/// a clearer message than a Compact assert.
 fn sort_signatures_by_validator_index(
     message: &HyperlaneMessage,
     metadata: &mut WireMetadata,
@@ -311,11 +281,9 @@ fn sort_signatures_by_validator_index(
     Ok(())
 }
 
-/// keccak(domainHash || root || index_be || messageId), where
-/// domainHash = keccak(origin_domain_be32 || merkle_tree_hook || "HYPERLANE").
-/// Matches the on-chain Midnight MessageIdMultisigIsm digest pre-EIP-191
-/// (validators sign the EIP-191 wrap of this; ecrecover with
-/// RecoveryMessage::Data applies the same wrap).
+/// keccak(domainHash || root || index_be || messageId), where domainHash =
+/// keccak(origin_domain_be32 || merkle_tree_hook || "HYPERLANE"). This is the
+/// digest before the EIP-191 wrap that validators actually sign.
 fn compute_checkpoint_inner_hash(
     message: &HyperlaneMessage,
     metadata: &WireMetadata,
@@ -360,8 +328,7 @@ fn recover_signer(inner_hash: &[u8; 32], sig_bytes: &[u8]) -> ChainResult<H160> 
     let recovered = sig
         .recover(inner_hash.to_vec())
         .map_err(|e| HyperlaneMidnightError::Other(format!("ecrecover failed: {e}")))?;
-    // ethers::types::H160 and hyperlane_core::H160 are both 20-byte primitive
-    // hashes but distinct types; convert through the inner byte array.
+    // ethers' H160 and hyperlane_core's are distinct types; go via the bytes.
     Ok(H160::from(recovered.0))
 }
 
@@ -390,7 +357,6 @@ mod tests {
         );
         assert_eq!(parsed.root, format!("0x{}", hex::encode([0xCDu8; 32])));
         assert_eq!(parsed.index, 42);
-        // No padding: exactly the two real signatures the blob carried.
         assert_eq!(parsed.signatures.len(), 2);
         assert_eq!(
             parsed.signatures[0],
@@ -462,13 +428,12 @@ mod tests {
         let sig1_hex = format!("0x{}", hex::encode(<[u8; 65]>::from(sig1)));
         let zero_hex = format!("0x{}", hex::encode([0u8; SIGNATURE_LEN]));
 
-        // Insert signatures in REVERSE validator-index order, plus a stale zero
-        // pad that the sort must drop (it never re-pads).
+        // Reverse validator-index order, plus a stale zero pad the sort must
+        // drop without re-padding.
         metadata.signatures = vec![sig1_hex.clone(), sig0_hex.clone(), zero_hex.clone()];
 
         sort_signatures_by_validator_index(&message, &mut metadata, &validators).unwrap();
 
-        // Reordered to validator-index order, zero padding dropped, no re-pad.
         assert_eq!(metadata.signatures.len(), 2);
         assert_eq!(metadata.signatures[0], sig0_hex);
         assert_eq!(metadata.signatures[1], sig1_hex);
@@ -486,7 +451,6 @@ mod tests {
             "9999999999999999999999999999999999999999999999999999999999999999"
                 .parse()
                 .unwrap();
-        // Validator set knows only k_known; k_rogue must be rejected.
         let validators = vec![H160::from(k_known.address().0)];
 
         let message = HyperlaneMessage {

--- a/rust/main/chains/hyperlane-midnight/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-midnight/src/merkle_tree_hook.rs
@@ -1,38 +1,13 @@
-//! `MerkleTreeHook` + `MerkleTreeHookIndexer` for Midnight.
+//! `MerkleTreeHook` + `MerkleTreeHookIndexer` for Midnight, fused onto one
+//! struct the way Aleo and Radix do it.
 //!
-//! Both the contract abstraction (root/count/checkpoint reads) and the
-//! sequence-aware indexer (leaf insertions) are implemented on one
-//! `MidnightMerkleTreeHook` struct — the fused shape Aleo and Radix use, and
-//! the one the fork already scopes under #15 (`build_merkle_tree_hook`
-//! errored with "see issue #15" and `build_merkle_tree_hook_indexer` carried
-//! a `TODO(#15)`).
-//!
-//! The WarpRoute (`night`) contract is monolithic, so there is no separate
-//! merkle-tree-hook contract: the Mailbox module lives in the same contract as
-//! the ISM. The `night` contract does NOT maintain an on-chain merkle tree
-//! (Hyperlane's MessageId security model never reads an origin-chain root, and
-//! the in-circuit keccak walk that a replicated tree needs dominated the
-//! outbound proving key), so the CONTRACT half of this hook (`tree()` /
-//! `count()` / `latest_checkpoint()`) reconstructs the tree entirely off-chain
-//! by ingesting the append-only `dispatched_messages` map read from the
-//! deployed contract's state via the #14 indexer client, decoded by
-//! [`crate::state_decode`]. Sealevel likewise rebuilds its tree from the
-//! mailbox/outbox account; we mirror that.
-//!
-//! The INDEXER half is event-based (#95): it derives one
-//! `MerkleTreeInsertion(nonce, message.id())` per `HYP_DISPATCH` Misc event,
-//! fetched over block ranges — the same events the dispatch indexer replays,
-//! so the leaves it emits are exactly the messages the state reconstruction
-//! ingests.
-//!
-//! How the validator uses this (`agents/validator/src/submit.rs`): it feeds
-//! the `MerkleTreeInsertion`s emitted by the indexer into its local RocksDB
-//! merkle replica, then compares the replica's root against the root returned
-//! by [`MerkleTreeHook::latest_checkpoint`]. Both come from the same off-chain
-//! reconstruction (`tree()` -> `checkpoint_from_tree`), so the cross-check is
-//! self-consistent. The leaves match because the on-chain message id is
-//! `keccak256(message)` (real in-circuit keccak, #21), so `HyperlaneMessage::id()`
-//! on the Rust side reproduces the exact leaf the destination ISM re-derives.
+//! The WarpRoute contract keeps no on-chain merkle tree — Hyperlane's
+//! MessageId security model never reads an origin-chain root, and the
+//! in-circuit keccak walk a replicated tree needs dominated the outbound
+//! proving key. So the contract reads (`tree` / `count` /
+//! `latest_checkpoint`) rebuild the tree off-chain from the append-only
+//! `dispatched_messages` map, as Sealevel does from its outbox account, while
+//! the indexer half derives one leaf per `HYP_DISPATCH` event.
 
 use std::ops::RangeInclusive;
 
@@ -53,10 +28,9 @@ use crate::indexer_client::MiscEvent;
 use crate::state_decode::decode_dispatched_messages;
 use crate::MidnightProvider;
 
-/// Midnight reads only finalized contract state (BFT finality; the runtime API
-/// exposes block-final state), so a configured `reorg_period` is ignored. Log
-/// it rather than silently dropping it, so an operator who set one sees why it
-/// has no effect (Sealevel asserts instead; we prefer not to panic).
+/// Midnight has BFT finality and the indexer serves only finalized state, so a
+/// configured `reorg_period` has no effect. Log it rather than drop it
+/// silently, so an operator who set one finds out why.
 fn note_reorg_ignored(reorg_period: &ReorgPeriod) {
     if !reorg_period.is_none() {
         tracing::debug!(
@@ -66,13 +40,6 @@ fn note_reorg_ignored(reorg_period: &ReorgPeriod) {
     }
 }
 
-/// Build a checkpoint from the off-chain reconstructed merkle tree. The
-/// WarpRoute does not maintain an on-chain merkle tree — Hyperlane's MessageId
-/// security model never reads an origin-chain root — so the validator's local
-/// replica is the sole source of the root. The checkpoint root is therefore
-/// `tree.root()`, exactly what the validator signs in `submit.rs`, so its
-/// local-vs-anchor cross-check is self-consistent. Errors on an empty tree
-/// (nothing to sign yet); `index = count - 1`.
 fn checkpoint_from_tree(
     tree: &IncrementalMerkle,
     merkle_tree_hook_address: H256,
@@ -94,14 +61,9 @@ fn checkpoint_from_tree(
     })
 }
 
-/// Build a `MerkleTreeInsertion` for every `HYP_DISPATCH` event in a
-/// Misc-event batch. Every dispatch inserts exactly one leaf, so
-/// `leaf_index == nonce` (decoded from the 141-byte message wire form) and
-/// `message_id == HyperlaneMessage::id()` (keccak of those bytes — the same
-/// leaf the destination ISM re-derives). `insertion.into()` sets
-/// `Indexed.sequence = leaf_index`, which the sequence-aware cursor keys on.
-/// Non-dispatch events are skipped; a dispatch that fails to decode is an
-/// error, not a skip.
+/// Every dispatch inserts exactly one leaf, so `leaf_index == nonce` and the
+/// leaf is the message's keccak id — the same one the destination ISM
+/// re-derives.
 fn insertions_from_events(
     events: &[MiscEvent],
     address: H256,
@@ -117,10 +79,7 @@ fn insertions_from_events(
         .collect()
 }
 
-/// Chain-sourced `MerkleTreeHook` + indexer for Midnight's monolithic
-/// WarpRoute. Reads the append-only `dispatched_messages` map from the deployed
-/// contract's on-chain state and reconstructs the incremental merkle tree from
-/// it off-chain; the contract keeps no on-chain tree.
+/// `MerkleTreeHook` + indexer for Midnight's monolithic WarpRoute.
 #[derive(Debug, Clone)]
 pub struct MidnightMerkleTreeHook {
     address: H256,
@@ -129,9 +88,7 @@ pub struct MidnightMerkleTreeHook {
 }
 
 impl MidnightMerkleTreeHook {
-    /// Construct a handle to the WarpRoute's merkle tree hook. `address` is the
-    /// monolithic `night` contract (the same address used for the mailbox and
-    /// ISM).
+    /// `address` is the monolithic contract, shared with the mailbox and ISM.
     pub fn new(address: H256, domain: HyperlaneDomain, provider: MidnightProvider) -> Self {
         Self {
             address,
@@ -140,13 +97,10 @@ impl MidnightMerkleTreeHook {
         }
     }
 
-    /// Contract address as the indexer's bare-hex scalar (no `0x`), matching
-    /// the form `MidnightInterchainSecurityModule` already uses.
     fn address_hex(&self) -> String {
         format!("{:x}", self.address)
     }
 
-    /// Fetch + decode the dispatched messages, sorted by nonce.
     async fn dispatched_messages(
         &self,
     ) -> ChainResult<Vec<(u32, hyperlane_core::HyperlaneMessage)>> {
@@ -158,9 +112,6 @@ impl MidnightMerkleTreeHook {
         decode_dispatched_messages(&bytes)
     }
 
-    /// Latest indexer block height, narrowed to the `u32` Hyperlane uses for
-    /// block numbers. Saturates rather than truncating; Midnight devnet
-    /// heights are far below `u32::MAX`.
     async fn latest_height_u32(&self) -> ChainResult<u32> {
         let height = self
             .provider
@@ -190,11 +141,6 @@ impl HyperlaneContract for MidnightMerkleTreeHook {
 
 #[async_trait]
 impl MerkleTreeHook for MidnightMerkleTreeHook {
-    /// Reconstruct the incremental merkle tree by ingesting every dispatched
-    /// message id in nonce order. Reproduces the on-chain tree (same leaves,
-    /// same Hyperlane incremental-merkle algorithm). Midnight has no
-    /// point-in-time state reads (the indexer `offset` is deferred), so
-    /// `reorg_period` is ignored — Midnight has BFT finality and no reorgs.
     async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
         note_reorg_ignored(reorg_period);
         let messages = self.dispatched_messages().await?;
@@ -210,15 +156,11 @@ impl MerkleTreeHook for MidnightMerkleTreeHook {
 
     async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
         note_reorg_ignored(reorg_period);
-        // The contract keeps no on-chain leaf count; derive it from the
-        // off-chain reconstruction (same source as `tree()`).
         Ok(self.tree(reorg_period).await?.tree.count() as u32)
     }
 
-    /// The latest checkpoint, built from the off-chain reconstructed tree. The
-    /// contract keeps no on-chain root, and this root is exactly the one the
-    /// validator signs (`submit.rs` `tree.root()`), so the validator's
-    /// correctness cross-check is self-consistent. Errors on an empty tree.
+    /// This root is the one the validator signs, so its local cross-check is
+    /// against the same reconstruction.
     async fn latest_checkpoint(
         &self,
         reorg_period: &ReorgPeriod,
@@ -228,9 +170,8 @@ impl MerkleTreeHook for MidnightMerkleTreeHook {
         checkpoint_from_tree(&tree, self.address, self.domain.id())
     }
 
-    /// Midnight cannot read point-in-time state yet (indexer `offset` is
-    /// deferred), so this returns the latest checkpoint regardless of height,
-    /// the same stance as Sealevel.
+    /// Midnight cannot read point-in-time state yet, so this returns the latest
+    /// checkpoint regardless of height.
     async fn latest_checkpoint_at_block(&self, _height: u64) -> ChainResult<CheckpointAtBlock> {
         self.latest_checkpoint(&ReorgPeriod::None).await
     }
@@ -238,10 +179,6 @@ impl MerkleTreeHook for MidnightMerkleTreeHook {
 
 #[async_trait]
 impl Indexer<MerkleTreeInsertion> for MidnightMerkleTreeHook {
-    /// Midnight indexes insertions over BLOCK ranges (`IndexMode::Block`, EVM
-    /// parity, #95): replay the `HYP_DISPATCH` events in the range and derive
-    /// one leaf per dispatch. The sequence-aware cursor validates leaf-index
-    /// contiguity across ranges.
     async fn fetch_logs_in_range(
         &self,
         range: RangeInclusive<u32>,
@@ -255,8 +192,6 @@ impl Indexer<MerkleTreeInsertion> for MidnightMerkleTreeHook {
     }
 
     /// Midnight has BFT finality, so the latest observed height is final.
-    /// Returns it (rather than panicking like Sealevel's merkle indexer) so
-    /// any framework path that reads it gets a sane watermark.
     async fn get_finalized_block_number(&self) -> ChainResult<u32> {
         self.latest_height_u32().await
     }
@@ -265,9 +200,8 @@ impl Indexer<MerkleTreeInsertion> for MidnightMerkleTreeHook {
         &self,
         tx_hash: H512,
     ) -> ChainResult<Vec<(Indexed<MerkleTreeInsertion>, LogMeta)>> {
-        // The relayer broadcasts dispatch txids from the message sync task to
-        // the merkle sync task; the dispatch and the insertion are the same
-        // event on Midnight, so the transactionHash filter serves both.
+        // A dispatch and its insertion are the same event on Midnight, so the
+        // transactionHash filter serves both sync tasks.
         let Some(tx_hash) = h512_to_h256(tx_hash) else {
             return Ok(Vec::new());
         };
@@ -283,11 +217,9 @@ impl Indexer<MerkleTreeInsertion> for MidnightMerkleTreeHook {
 #[async_trait]
 impl SequenceAwareIndexer<MerkleTreeInsertion> for MidnightMerkleTreeHook {
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        // Every dispatch inserts exactly one leaf, so the Mailbox `nonce`
-        // counter IS the leaf count — a cheap state read (one fetch, one
-        // counter decode) instead of rebuilding the whole tree per cursor
-        // tick. `count()` (the MerkleTreeHook contract read) still derives
-        // from the full reconstruction above.
+        // Every dispatch inserts one leaf, so the Mailbox `nonce` counter is
+        // the leaf count — one cheap state read instead of rebuilding the whole
+        // tree on every cursor tick.
         let tip = self.latest_height_u32().await?;
         let count = self
             .provider
@@ -310,9 +242,8 @@ mod tests {
         H256::repeat_byte(0xaa)
     }
 
-    // Empty tree (count == 0) is the day-one state of every deployment, before
-    // the first dispatch — the validator hits it at startup. `latest_checkpoint`
-    // must surface "no checkpoint", not index-underflow.
+    // The validator hits this at startup, so it must surface "no checkpoint"
+    // rather than an index underflow.
     #[test]
     fn checkpoint_errors_on_empty_tree() {
         let tree = IncrementalMerkle::default();
@@ -339,12 +270,8 @@ mod tests {
         assert_eq!(cp.checkpoint.merkle_tree_hook_address, test_addr());
     }
 
-    // The core indexer logic the validator consumes: every HYP_DISPATCH event
-    // yields one leaf with `sequence == leaf_index == nonce` and
-    // `message_id == HyperlaneMessage::id()`, carried with the real per-event
-    // LogMeta. The leaves are cross-checked against the SAME messages decoded
-    // from the committed state fixture, proving the event-derived leaves match
-    // what the state reconstruction (`tree()`) ingests.
+    // Cross-checks the event-derived leaves against the same messages decoded
+    // from the state fixture, which is the parity `tree()` depends on.
     #[test]
     fn insertions_derive_from_dispatch_events() {
         use hyperlane_core::{Encode as _, U256};
@@ -358,10 +285,8 @@ mod tests {
         messages.sort_by_key(|(nonce, _)| *nonce);
         assert_eq!(messages.len(), 2, "fixture has two dispatches");
 
-        // The wire bytes the contract emits are exactly the encoded message.
         let events = vec![
             misc_event(1, HYP_DISPATCH, &messages[0].1.to_vec()),
-            // A non-dispatch event in the same range is not an insertion.
             misc_event(2, HYP_PROCESS, H256::repeat_byte(0x11).as_bytes()),
             misc_event(3, HYP_DISPATCH, &messages[1].1.to_vec()),
         ];
@@ -380,7 +305,6 @@ mod tests {
             MerkleTreeInsertion::new(1, messages[1].1.id())
         );
 
-        // Real per-event LogMeta.
         assert_eq!(all[0].1.address, test_addr());
         assert_eq!(all[0].1.block_number, events[0].block_height);
         assert_eq!(all[0].1.block_hash, events[0].block_hash);
@@ -389,17 +313,9 @@ mod tests {
         assert_eq!(all[0].1.log_index, U256::from(events[0].id));
     }
 
-    /// Live integration test against a running Midnight devnet with at least
-    /// one dispatch. Exercises the full merkle path end to end: the leaf
-    /// count, that `fetch_logs_in_range` over the whole block range yields
-    /// one insertion per leaf (from the HYP_DISPATCH events), and that a
-    /// local `IncrementalMerkle` rebuilt from those insertions matches the
-    /// root returned by `latest_checkpoint` (which reconstructs from the
-    /// `dispatched_messages` state) — the event/state parity the validator
-    /// relies on. This is the "roots match on synthetic traffic" acceptance
-    /// check; the panic-on-mismatch half lives in the upstream validator
-    /// submitter and is covered by the outbound E2E (#26). Ignored by
-    /// default; run after a `transferRemote`:
+    /// Live check that a tree rebuilt from the indexer's insertions matches the
+    /// root `latest_checkpoint` reconstructs from state — the event/state
+    /// parity the validator relies on. Run after a `transferRemote`:
     ///
     ///   MIDNIGHT_INDEXER_URL=http://127.0.0.1:8088/api/v3/graphql \
     ///   MIDNIGHT_NIGHT_ADDRESS=<deployed night address hex> \
@@ -429,7 +345,6 @@ mod tests {
             "dispatch at least one message before running this"
         );
 
-        // Block-range fetch (IndexMode::Block): the whole chain so far.
         let logs = hook
             .fetch_logs_in_range(0..=tip)
             .await
@@ -457,19 +372,10 @@ mod tests {
         );
     }
 
-    // #17: the validator signs Midnight-origin checkpoints with the upstream,
-    // chain-agnostic signing path. This proves, offline (no node, no proof),
-    // that the checkpoint a Midnight validator produces is byte-identical to an
-    // EVM-origin checkpoint and that a standard Hyperlane signature over it
-    // recovers to the expected validator address.
-    //
-    // The committed `hyperlane-checkpoint-vector.json` is generated by
-    // `contracts/tests/utils/generate-checkpoint-vector.ts` from the SAME
-    // two-dispatch scenario as `night-state-dispatched.hex`, with the digest +
-    // signature produced by the independent `@hyperlane-xyz/utils` oracle. This
-    // test first cross-checks that the committed fixture and the committed
-    // vector describe one dispatch state (drift guard), then asserts the Rust
-    // signing path matches the EVM oracle byte-for-byte.
+    // Proves offline that a Midnight-origin checkpoint is byte-identical to an
+    // EVM-origin one and that a standard Hyperlane signature over it recovers
+    // to the expected validator. The committed vector's digests and signature
+    // come from the independent `@hyperlane-xyz/utils` oracle.
     #[test]
     fn checkpoint_signing_matches_evm_reference_vector() {
         use hyperlane_core::{CheckpointWithMessageId, Signable, Signature, SignedType, H160};
@@ -499,17 +405,14 @@ mod tests {
         ))
         .expect("vector json parses");
 
-        // --- Drift guard: the committed fixture and vector are one dispatch ---
+        // Drift guard: the committed fixture and vector must describe one
+        // dispatch state.
         let bytes =
             hex::decode(include_str!("../tests/fixtures/night-state-dispatched.hex").trim())
                 .expect("fixture is valid hex");
         let mut messages = decode_dispatched_messages(&bytes).expect("decode dispatched messages");
         messages.sort_by_key(|(nonce, _)| *nonce);
 
-        // Local tree rebuilt from the indexer's leaves reproduces the EVM
-        // vector's `root` input. The contract keeps no on-chain root, so this
-        // off-chain reconstruction is the sole source — exactly the root the
-        // validator signs.
         let mut tree = IncrementalMerkle::default();
         for (_nonce, message) in &messages {
             tree.ingest(message.id());
@@ -531,7 +434,6 @@ mod tests {
             "fixture tip messageId must match the vector (fixture/vector drift)"
         );
 
-        // --- Build the checkpoint the validator would sign ---
         let checkpoint = CheckpointWithMessageId {
             checkpoint: Checkpoint {
                 merkle_tree_hook_address: h256(&vector.merkle_tree_hook),
@@ -542,9 +444,8 @@ mod tests {
             message_id: h256(&vector.message_id),
         };
 
-        // Domain hash matches `domain_hash(merkle_tree_hook, origin)` — a redundant
-        // layer (it also feeds `inner` below), but it localises a domain-hash bug
-        // one step earlier instead of only surfacing in the inner-digest assert.
+        // Redundant with the inner digest below, but it localises a domain-hash
+        // bug one step earlier.
         assert_eq!(
             hyperlane_core::utils::domain_hash(
                 checkpoint.merkle_tree_hook_address,
@@ -554,8 +455,6 @@ mod tests {
             "domain_hash(merkle_tree_hook, origin) must equal the EVM reference domainHash"
         );
 
-        // Rust signing hash == EVM oracle inner hash (BaseValidator.messageHash);
-        // EIP-191 wrap == oracle digest. Byte-identical => format parity.
         assert_eq!(
             checkpoint.signing_hash(),
             h256(&vector.inner),
@@ -567,8 +466,6 @@ mod tests {
             "EIP-191 digest must equal the EVM reference digest"
         );
 
-        // A standard Hyperlane signature over that checkpoint recovers to the
-        // expected validator address — the exact destination-side verify path.
         let sig_bytes = hex::decode(vector.signature.trim_start_matches("0x")).expect("sig hex");
         let signature: Signature = ethers::core::types::Signature::try_from(sig_bytes.as_slice())
             .expect("65-byte signature")

--- a/rust/main/chains/hyperlane-midnight/src/metadata_tests.rs
+++ b/rust/main/chains/hyperlane-midnight/src/metadata_tests.rs
@@ -1,33 +1,15 @@
-//! #18: relayer outbound metadata parity — Midnight as the ORIGIN chain.
+//! Outbound metadata parity with Midnight as the origin chain.
 //!
-//! The relayer's two outbound responsibilities are (a) listing pending
-//! Midnight-origin messages and (b) assembling MultisigIsm metadata a STANDARD
-//! destination ISM verifies. Both are chain-agnostic upstream once the Midnight
-//! crate supplies the standard traits (dispatch indexer #16, merkle indexer #15,
-//! validator announce #33, chain-sourced ISM #14) and the validator signs
-//! standard checkpoints (#17) — the relayer's `MessageIdMultisigMetadataBuilder`
-//! contains no chain-specific code (verified: zero `midnight`/`aleo`/`sealevel`
-//! references in `agents/relayer/src`). Enumeration is covered in `indexer.rs`
-//! (`dispatch_enumerates_committed_fixture_in_sequence`).
-//!
-//! This module closes the second half: it proves that the MessageIdMultisig
-//! metadata blob built from a Midnight-origin checkpoint is byte-shaped exactly
-//! as a stock EVM `MessageIdMultisigIsm` expects, and that the destination's
-//! forward-only two-pointer verification accepts it. #17's checkpoint vector
-//! already pins the SINGLE checkpoint digest + one signature against the EVM
-//! oracle; this goes one layer out to the assembled M-of-N metadata structure:
+//! Proves that the MessageIdMultisig metadata assembled from a Midnight-origin
+//! checkpoint has the byte layout a stock EVM `MessageIdMultisigIsm` expects:
 //!
 //!   merkleTreeHook(32) || root(32) || index(u32 BE, 4) || signature(65) * M
 //!
-//! The committed `hyperlane-metadata-vector.json` is generated offline (no node,
-//! no proof) by `contracts/tests/utils/generate-metadata-vector.ts` from the
-//! SAME two-dispatch scenario as `night-state-dispatched.hex`, with digests and
-//! signatures produced by the independent `@hyperlane-xyz/utils` oracle. This
-//! test first drift-guards the fixture against the vector (one dispatch state),
-//! then asserts the digest parity and runs the exact destination-side
-//! verification. The signing subset is chosen to be descending by address while
-//! ascending by set index, so the ordering requirement is exercised
-//! adversarially (a verifier matching by address would reject it).
+//! and that the destination's forward-only verification accepts it. Digests and
+//! signatures in the committed vector come from the independent
+//! `@hyperlane-xyz/utils` oracle. The signing subset is deliberately descending
+//! by address while ascending by set index, so a verifier that matched by
+//! address instead of index would fail here.
 
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle, Checkpoint, CheckpointWithMessageId, Signable,
@@ -45,15 +27,14 @@ struct MetadataVector {
     root: String,
     index: u32,
     message_id: String,
-    /// Inner checkpoint digest (`BaseValidator.messageHash`) from the oracle.
+    /// Inner checkpoint digest (`BaseValidator.messageHash`).
     inner: String,
-    /// EIP-191-wrapped digest the validators signed, from the oracle.
+    /// EIP-191-wrapped digest the validators signed.
     digest: String,
     threshold: usize,
-    /// Full validator set in configured (index) order, as the destination ISM
-    /// walks it.
+    /// Full validator set in index order, as the destination ISM walks it.
     validators: Vec<String>,
-    /// Signatures in ascending validator-index order (the subset that signed).
+    /// The subset that signed, in ascending validator-index order.
     signatures: Vec<String>,
     /// The assembled MessageIdMultisig metadata blob.
     metadata: String,
@@ -77,16 +58,14 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
     ))
     .expect("vector json parses");
 
-    // --- Drift guard: the committed fixture and this vector are one dispatch ---
+    // Drift guard: the committed fixture and this vector must describe one
+    // dispatch state.
     let fixture = hex::decode(include_str!("../tests/fixtures/night-state-dispatched.hex").trim())
         .expect("fixture is valid hex");
 
     let mut messages = decode_dispatched_messages(&fixture).expect("decode dispatched messages");
     messages.sort_by_key(|(nonce, _)| *nonce);
 
-    // A local replica rebuilt from the dispatch leaves reproduces the vector's
-    // root input. The contract keeps no on-chain root, so this reconstruction
-    // is the sole source — exactly the root the validator signs.
     let mut tree = IncrementalMerkle::default();
     for (_nonce, message) in &messages {
         tree.ingest(message.id());
@@ -108,7 +87,6 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         "fixture tip messageId must match the vector (fixture/vector drift)"
     );
 
-    // --- Byte layout the destination MessageIdMultisigIsm reads ---
     let blob = bytes(&vector.metadata);
     assert_eq!(
         blob.len(),
@@ -116,8 +94,8 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         "metadata length is 68 + 65*threshold"
     );
 
-    // Parse the checkpoint fields straight out of the blob, exactly as the
-    // destination ISM does, and confirm they equal the vector's fields.
+    // Parse the checkpoint fields out of the blob the way the destination ISM
+    // does.
     let blob_mth = H256::from_slice(&blob[0..32]);
     let blob_root = H256::from_slice(&blob[32..64]);
     let blob_index = u32::from_be_bytes(blob[64..68].try_into().unwrap());
@@ -129,7 +107,6 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
     assert_eq!(blob_root, h256(&vector.root), "root");
     assert_eq!(blob_index, vector.index, "index is big-endian u32");
 
-    // The flat `signatures` list must equal the blob's signature section.
     for (i, sig_hex) in vector.signatures.iter().enumerate() {
         let start = METADATA_PREFIX_LEN + i * SIGNATURE_LEN;
         assert_eq!(
@@ -139,11 +116,8 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         );
     }
 
-    // --- Destination-side verification: reconstruct the checkpoint from the
-    //     blob + the delivered message's id (what the ISM has), recover each
-    //     signature, and match the validator set with a forward-only pointer.
-    //     This is exactly the EVM MessageIdMultisigIsm check; passing it means
-    //     the Midnight-origin metadata is consumable unchanged. ---
+    // Destination-side verification: rebuild the checkpoint from the blob plus
+    // the delivered message's id, which is all the ISM has.
     let checkpoint = CheckpointWithMessageId {
         checkpoint: Checkpoint {
             merkle_tree_hook_address: blob_mth,
@@ -151,16 +125,12 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
             root: blob_root,
             index: blob_index,
         },
-        // The destination computes the messageId from the delivered message, not
-        // from the metadata (the blob carries no messageId field). Use the
-        // fixture's tip id, already asserted equal to the vector's.
+        // The blob carries no messageId field, so the destination computes it
+        // from the delivered message.
         message_id: tip.1.id(),
     };
-    // Digest parity: the checkpoint the destination reconstructs hashes to the
-    // same inner + EIP-191 digest the validators signed (produced by the
-    // independent `@hyperlane-xyz/utils` oracle). Asserting this here localises a
-    // digest-construction regression to a clear failure, instead of surfacing as
-    // a confusing "signer not in set" once recovery runs against a wrong digest.
+    // Checked before recovery: a digest bug surfaces here rather than as a
+    // confusing "signer not in set" further down.
     assert_eq!(
         checkpoint.signing_hash(),
         h256(&vector.inner),
@@ -178,7 +148,6 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         .map(|v| H160::from_slice(&bytes(v)))
         .collect();
 
-    // Recover signers from the blob's signature section, in blob order.
     let mut recovered: Vec<H160> = Vec::with_capacity(vector.threshold);
     for i in 0..vector.threshold {
         let start = METADATA_PREFIX_LEN + i * SIGNATURE_LEN;
@@ -193,10 +162,8 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         recovered.push(signed.recover().expect("recover signer"));
     }
 
-    // Forward-only two-pointer over the validator set: each recovered signer
-    // matches a validator at a strictly increasing index. This enforces both the
-    // ascending-order requirement and implicit duplicate rejection — identical to
-    // the destination ISM's walk.
+    // The destination ISM's walk: each signer must match a validator at a
+    // strictly increasing index, which also rejects duplicates.
     let mut vptr = 0usize;
     let mut matched = 0usize;
     for signer in &recovered {
@@ -215,20 +182,16 @@ fn metadata_matches_fixture_and_verifies_as_standard_multisig() {
         "all signatures matched distinct validators in ascending index order"
     );
 
-    // Concretely: the vector's signers are validators 0 and 2 (index 1 skipped),
-    // so the two-pointer walk must have skipped the middle validator.
+    // The vector's signers are validators 0 and 2, so the walk had to skip the
+    // middle one.
     assert_eq!(
         recovered,
         vec![validators[0], validators[2]],
         "signers are the ascending set-index subset {{0, 2}} the vector encodes"
     );
 
-    // Sharpened ordering check: those signers are DESCENDING by address (the
-    // vector's validator set is ordered so index 0 has a larger address than
-    // index 2). A verifier that matched by address order rather than set index
-    // would have rejected this order. Passing the forward-only walk above while
-    // this holds proves the ordering requirement is enforced by SET INDEX, not by
-    // address — a subset ascending under both orderings could not prove that.
+    // Those two signers descend by address, so passing the walk above proves
+    // the ordering is enforced by set index and not by address.
     assert!(
         recovered[0] > recovered[1],
         "signing subset must be descending by address so the index-order requirement is adversarial"

--- a/rust/main/chains/hyperlane-midnight/src/provider.rs
+++ b/rust/main/chains/hyperlane-midnight/src/provider.rs
@@ -17,22 +17,18 @@ use crate::{ConnectionConf, MidnightIndexerClient};
 /// are cached.
 const WALLET_BALANCE_TTL: Duration = Duration::from_secs(300);
 
-/// Chain provider backed by the Midnight indexer's GraphQL API. Serves the
-/// block/transaction lookups the scraper needs (`ensure_blocks` /
-/// `ensure_txns` in `agents/scraper/src/store/storage.rs`) plus the contract
-/// state reads the other Midnight abstractions share.
+/// Chain provider backed by the Midnight indexer's GraphQL API.
 #[derive(Debug, Clone)]
 pub struct MidnightProvider {
     domain: HyperlaneDomain,
     indexer: MidnightIndexerClient,
-    /// Sidecar context for wallet-balance reads; `None` without a chain config.
     toolkit_ctx: Option<ToolkitContext>,
     /// Shared across clones so every consumer sees one TTL window.
     wallet_balance_cache: Arc<Mutex<Option<(Instant, String, U256)>>>,
 }
 
 impl MidnightProvider {
-    /// Build a new provider with contract-state reads only.
+    /// Contract-state reads only; `get_balance` cannot answer wallet addresses.
     pub fn new(domain: HyperlaneDomain, indexer: MidnightIndexerClient) -> Self {
         Self {
             domain,
@@ -42,8 +38,8 @@ impl MidnightProvider {
         }
     }
 
-    /// Build a provider from the chain config, wiring the submit sidecar so
-    /// `get_balance` can also answer the relayer wallet's own address.
+    /// Wires the sidecar too, so `get_balance` can answer the relayer wallet's
+    /// own address.
     pub fn from_conf(domain: HyperlaneDomain, conf: &ConnectionConf) -> Self {
         let indexer = MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
         let mut provider = Self::new(domain, indexer);
@@ -51,8 +47,7 @@ impl MidnightProvider {
         provider
     }
 
-    /// Borrow the indexer client, for chain-state reads (e.g. the ISM reading
-    /// its validators/threshold/module-type from the deployed contract).
+    /// The indexer client, for chain-state reads.
     pub fn indexer(&self) -> &MidnightIndexerClient {
         &self.indexer
     }
@@ -88,9 +83,8 @@ impl MidnightProvider {
     }
 }
 
-/// Map indexer block details onto the `BlockInfo` the scraper stores.
-/// `BlockInfo.timestamp` is unix SECONDS per the trait contract; the indexer
-/// reports unix milliseconds (Substrate `Timestamp::set`).
+/// `BlockInfo.timestamp` is unix seconds per the trait contract, but the indexer
+/// reports milliseconds.
 fn block_info_from(details: BlockDetails) -> BlockInfo {
     BlockInfo {
         hash: details.hash,
@@ -99,13 +93,9 @@ fn block_info_from(details: BlockDetails) -> BlockInfo {
     }
 }
 
-/// Map indexer transaction details onto the `TxnInfo` the scraper stores.
-/// Midnight has no gas market: fees are paid in DUST (SPECK), so the paid fee
-/// stands in for `gas_limit`/`gas_used` (the Aleo stance) and the price
-/// fields are unset. There is no public sender/nonce (shielded transactions),
-/// so `sender` is zero and `nonce` 0. `receipt` must be `Some` — the
-/// scraper's `store_txns` rejects receipt-less transactions as "not yet
-/// included", and everything the indexer serves is final.
+/// Midnight has no gas market, so the paid DUST fee stands in for the gas fields;
+/// transactions are shielded, so there is no public sender or nonce. The receipt
+/// must be `Some` or the scraper treats the transaction as not yet included.
 fn txn_info_from(hash: H512, details: TransactionDetails) -> TxnInfo {
     let fee = details.fee_specks.unwrap_or_default();
     TxnInfo {
@@ -154,8 +144,6 @@ impl HyperlaneProvider for MidnightProvider {
     }
 
     async fn get_txn_by_hash(&self, hash: &H512) -> ChainResult<TxnInfo> {
-        // Hyperlane widens 32-byte hashes right-aligned; a non-zero upper
-        // half cannot be a Midnight tx hash.
         let narrow = h512_to_h256(*hash)
             .ok_or(HyperlaneProviderError::CouldNotFindTransactionByHash(*hash))?;
         let details = self
@@ -168,10 +156,9 @@ impl HyperlaneProvider for MidnightProvider {
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        // Returning false makes `pending_message` drop every inbound message
-        // at the `is_recipient_contract` gate. Every routable recipient on
-        // Midnight is the monolithic WarpRoute contract, so `true` is correct
-        // until non-WarpRoute recipients exist.
+        // Every routable recipient on Midnight is the monolithic WarpRoute
+        // contract, and `false` would make the relayer drop every inbound
+        // message at its `is_recipient_contract` gate.
         Ok(true)
     }
 
@@ -239,8 +226,6 @@ mod tests {
         );
         assert_eq!(info.hash, hash);
         assert_eq!(info.gas_limit, U256::from(12345), "paid fee stands in");
-        // The scraper's store_txns requires a receipt ("not yet included"
-        // otherwise); Midnight only serves final transactions.
         let receipt = info.receipt.expect("receipt is mandatory");
         assert_eq!(receipt.gas_used, U256::from(12345));
         assert_eq!(receipt.cumulative_gas_used, U256::from(12345));

--- a/rust/main/chains/hyperlane-midnight/src/signer.rs
+++ b/rust/main/chains/hyperlane-midnight/src/signer.rs
@@ -53,8 +53,7 @@ mod tests {
 
     #[test]
     fn signer_constructs() {
-        // `default()` rather than `new()`: the latter reads
-        // MIDNIGHT_RELAYER_ADDRESS from the ambient env.
+        // `default()` rather than `new()`, which reads the ambient env.
         let signer = MidnightSigner::default();
         assert_eq!(signer.address(), "");
         assert_eq!(signer.address_h256(), H256::zero());

--- a/rust/main/chains/hyperlane-midnight/src/state_decode.rs
+++ b/rust/main/chains/hyperlane-midnight/src/state_decode.rs
@@ -1,25 +1,10 @@
-//! Native Rust decode of the WarpRoute (`night`) contract's ledger state
-//! as served by the Midnight indexer (the `contractAction.state` hex blob).
+//! Native decode of the WarpRoute (`night`) contract's ledger state as served
+//! by the Midnight indexer.
 //!
-//! The `night` contract has no usable generated decoder — its compiled TS
-//! `Ledger` type is empty because its ledger fields live in imported
-//! modules. So we deserialize the tagged ledger state with the same crates
-//! the indexer uses (`midnight-onchain-state` / `midnight-serialize`) and
-//! navigate the resulting `StateValue::Array` positionally.
-//!
-//! Field positions are taken from the compiled `night` readers'
-//! `queryLedgerState` paths and verified against live deployed state in the
-//! tests below: `_validatorCount_0` -> `[0, 8]`, `_thresholdValue_0` ->
-//! `[0, 9]`, `_moduleType_0` -> `[0, 10]`, and the `validators` map at
-//! `[0, 7]`. Slots `[0, 11..13]` are the module's private `_verify_*` scratch
-//! fields, so `module_type` sits one slot from scratch state. The paths are
-//! pinned to the field declaration order in `MessageIdMultisigIsm.compact`;
-//! any reorder/insert above or between these fields shifts them. To
-//! re-verify after a contract change, recompile `night.compact` and grep the
-//! `queryLedgerState` paths in `managed/night/contract/index.js`. The
-//! contracts-repo CI asserts these paths on every compile, and
-//! `decode_ism_state` below fails loudly if the decoded fields are mutually
-//! inconsistent.
+//! The contract has no usable generated decoder — its compiled TS `Ledger`
+//! type is empty because the ledger fields live in imported modules. So the
+//! tagged state is deserialized with the same crates the indexer uses and the
+//! resulting `StateValue::Array` is navigated positionally.
 
 use hyperlane_core::{ChainResult, HyperlaneMessage};
 use midnight_onchain_state::state::{ContractState, StateValue};
@@ -28,57 +13,32 @@ use midnight_storage_core::DefaultDB;
 
 use crate::error::HyperlaneMidnightError;
 
-// Positional paths into the ledger `StateValue::Array`, from the compiled
-// `night` readers. `night`'s state is a 2-element root array: `[0]` holds the
-// ownership commitment + Routes `local_domain` scalar and the Routes routers
-// map, `[1]` holds the MessageIdMultisigIsm / Mailbox / Scale module fields
-// and the warp `destination_gas` map. The on-chain incremental merkle tree
-// was removed (the validator reconstructs it off-chain from
-// `dispatched_messages`), so there is no merkle `count` / `current_root`
-// slot to decode.
-//
-// The MessageIdMultisigIsm fields are consecutive slots under `[1]`, in
-// source-declaration order: validators(0), validator_count(1), threshold(2),
-// module_type(3).
+// Positional paths into the ledger `StateValue::Array`. Root `[0]` holds the
+// ownership commitment and the Routes fields, `[1]` the
+// MessageIdMultisigIsm / Mailbox / Scale module fields. Paths follow each
+// module's field declaration order, so inserting or reordering a field shifts
+// them; the contracts repo re-checks them on every compile.
 const ISM_VALIDATORS_PATH: [usize; 2] = [1, 0];
 const ISM_VALIDATOR_COUNT_PATH: [usize; 2] = [1, 1];
 const ISM_THRESHOLD_PATH: [usize; 2] = [1, 2];
 const ISM_MODULE_TYPE_PATH: [usize; 2] = [1, 3];
 
-// The Mailbox fields also live under `[1]`: deliveries(7), nonce(8),
-// dispatched_messages(9). Verified two ways:
-//   (1) The compiled `night` readers in `managed/night/contract/index.js`
-//       index these exact slots: `isDelivered`/`deliveryCount` -> `[1, 7]`
-//       (`deliveries` Set, `member`/`size`), `nonceValue` -> `[1, 8]`
-//       (`nonce` Counter, `popeq`), `messageAt` -> `[1, 9]` (the
-//       `dispatched_messages` Map, keyed `member`/`idx`).
-//   (2) Decoding a fresh post-dispatch state: root `[1]` is a 15-element array;
-//       `[1, 7]` is a Set, `[1, 8]` a Counter cell, `[1, 9]` a `Bytes<141>`
-//       Map. Matches the declaration order in `modules/Mailbox.compact`.
-// The paths are pinned to the compiled layout; adding or removing a field
-// shifts them, and the compiler rebalances the root cells as the field count
-// grows. The contracts-repo
-// layout guard re-checks the `queryLedgerState` paths on every compile.
-// (The `deliveries` set at `[1, 7]` is no longer decoded: deliveries are
-// indexed from `HYP_PROCESS` events, and the Mailbox `delivered` read goes
-// through the toolkit.)
+// Mailbox fields, also under `[1]`. Slot 7 is the `deliveries` set, which is
+// not decoded here: deliveries come from `HYP_PROCESS` events and the
+// `delivered` read goes through the toolkit.
 const MAILBOX_NONCE_PATH: [usize; 2] = [1, 8];
 const DISPATCHED_MESSAGES_PATH: [usize; 2] = [1, 9];
 
-/// Length in bytes of an encoded `HyperlaneMessage` stored in the
-/// `dispatched_messages` map (`Bytes<141>`) and carried in `HYP_DISPATCH`
-/// event payloads: version(1) + nonce(4) + origin(4) + sender(32) +
-/// destination(4) + recipient(32) + body(64).
+/// Length of an encoded `HyperlaneMessage`: version(1) + nonce(4) + origin(4)
+/// + sender(32) + destination(4) + recipient(32) + body(64).
 pub(crate) const ENCODED_MESSAGE_LEN: usize = 141;
 
 /// The MessageIdMultisigIsm configuration read from on-chain state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IsmState {
-    /// Validator addresses (20-byte ETH addresses), ordered by on-chain
-    /// slot index 0..validator_count. The on-chain registry stores each
-    /// validator as a `Bytes<64>` secp256k1 public key (X_be || Y_be, the
-    /// uncompressed SEC1 body without the 0x04 tag, #22); the decoder
-    /// derives the address as `keccak256(pubkey)[12..]`.
+    /// Validator addresses, in on-chain slot order. The registry stores
+    /// 64-byte secp256k1 public keys; the address is
+    /// `keccak256(pubkey)[12..]`.
     pub validators: Vec<[u8; 20]>,
     /// Number of populated validator slots.
     pub validator_count: u8,
@@ -88,14 +48,13 @@ pub struct IsmState {
     pub module_type: u8,
 }
 
-/// Deserialize the raw indexer-served state bytes into a `ContractState`.
+/// Deserialize the raw indexer-served state bytes.
 pub fn decode_contract_state(bytes: &[u8]) -> ChainResult<ContractState<DefaultDB>> {
     let mut reader = bytes;
     tagged_deserialize(&mut reader)
         .map_err(|e| HyperlaneMidnightError::StateDecode(e.to_string()).into())
 }
 
-/// Navigate a positional path through nested `StateValue::Array`s.
 fn nav<'a>(
     root: &'a StateValue<DefaultDB>,
     path: &[usize],
@@ -117,9 +76,8 @@ fn nav<'a>(
     Ok(node)
 }
 
-/// Raw atom bytes of a leaf `Cell`'s aligned value. Compact integers are
-/// little-endian with trailing zero bytes trimmed; byte arrays (`Bytes<N>`)
-/// are stored verbatim.
+/// Compact integers are little-endian with trailing zero bytes trimmed;
+/// `Bytes<N>` is stored verbatim.
 fn cell_atom(node: &StateValue<DefaultDB>) -> ChainResult<&[u8]> {
     match node {
         StateValue::Cell(sp) => {
@@ -136,7 +94,7 @@ fn cell_atom(node: &StateValue<DefaultDB>) -> ChainResult<&[u8]> {
     }
 }
 
-/// Read a `Uint<8>` leaf (value like 5; `0` is an empty atom).
+/// A zero `Uint<8>` is stored as an empty atom.
 fn read_u8(node: &StateValue<DefaultDB>) -> ChainResult<u8> {
     let bytes = cell_atom(node)?;
     match bytes.len() {
@@ -148,13 +106,8 @@ fn read_u8(node: &StateValue<DefaultDB>) -> ChainResult<u8> {
     }
 }
 
-/// Read a `Bytes<64>` leaf (a validator's secp256k1 public key, stored as
-/// X_be(32) || Y_be(32) — the uncompressed SEC1 body without the 0x04 tag).
-/// The runtime trims trailing zero bytes from a stored `Bytes<N>` leaf
-/// (`From<[u8; N]> for ValueAtom` drops them), so a pubkey whose Y coordinate
-/// ends in zero bytes is stored shorter than 64; right-pad back to the fixed
-/// width, the same trim/pad handling as the `Bytes<141>` message and
-/// `Bytes<32>` atom decoders. Only an over-long value is an error.
+/// A stored `Bytes<N>` leaf has its trailing zero bytes trimmed, so a key ending
+/// in zeros comes back short and has to be right-padded.
 fn read_bytes64(node: &StateValue<DefaultDB>) -> ChainResult<[u8; 64]> {
     let bytes = cell_atom(node)?;
     if bytes.len() > 64 {
@@ -169,12 +122,7 @@ fn read_bytes64(node: &StateValue<DefaultDB>) -> ChainResult<[u8; 64]> {
     Ok(pubkey)
 }
 
-/// Read the `validators: Map<Uint<8>, Bytes<64>>` ledger field — each value
-/// is a secp256k1 public key (X_be || Y_be, the uncompressed SEC1 body the
-/// in-circuit `secp256k1EcdsaVerify` checks against) — and derive each
-/// validator's 20-byte ETH address as `keccak256(pubkey)[12..]`, the standard
-/// Ethereum address derivation. Returned in ascending slot-index order (the
-/// order the on-chain multisig expects).
+/// Ascending slot-index order is what the on-chain multisig expects.
 fn read_validators(node: &StateValue<DefaultDB>) -> ChainResult<Vec<[u8; 20]>> {
     let map = match node {
         StateValue::Map(m) => m,
@@ -188,7 +136,6 @@ fn read_validators(node: &StateValue<DefaultDB>) -> ChainResult<Vec<[u8; 20]>> {
     let mut entries: Vec<(u8, [u8; 20])> = Vec::with_capacity(map.size());
     for entry in map.iter() {
         let pair = &*entry;
-        // key is an AlignedValue (the Uint<8> slot index); read its first byte.
         let key_av = &*pair.0;
         let idx = key_av
             .value
@@ -207,8 +154,7 @@ fn read_validators(node: &StateValue<DefaultDB>) -> ChainResult<Vec<[u8; 20]>> {
     Ok(entries.into_iter().map(|(_, addr)| addr).collect())
 }
 
-/// Decode the MessageIdMultisigIsm config (validators, threshold, module
-/// type) from the `night` contract's serialized ledger state.
+/// Decode the MessageIdMultisigIsm config from the serialized ledger state.
 pub fn decode_ism_state(bytes: &[u8]) -> ChainResult<IsmState> {
     let cs = decode_contract_state(bytes)?;
     let root = cs.data.get_ref();
@@ -219,11 +165,8 @@ pub fn decode_ism_state(bytes: &[u8]) -> ChainResult<IsmState> {
         module_type: read_u8(nav(root, &ISM_MODULE_TYPE_PATH)?)?,
     };
 
-    // Structural sanity: the decoded slots must be mutually consistent. A
-    // mismatch means the positional paths read the wrong slots (e.g. a
-    // contract layout shift), not a legitimate on-chain state. `module_type`
-    // is validated separately in `ism::module_type_from_u8`, which keeps this
-    // decoder agnostic to which ISM variants the agent supports.
+    // Mutually inconsistent slots mean the positional paths read the wrong
+    // fields, not a legitimate on-chain state.
     if state.validator_count as usize != state.validators.len() {
         return Err(HyperlaneMidnightError::StateDecode(format!(
             "validator_count {} does not match decoded validator set size {}",
@@ -243,9 +186,7 @@ pub fn decode_ism_state(bytes: &[u8]) -> ChainResult<IsmState> {
     Ok(state)
 }
 
-/// Read a little-endian unsigned integer leaf (a Compact `Counter`/`Uint<64>`)
-/// as a `u64`. The on-chain runtime trims trailing zero bytes, so a zero
-/// counter is an empty atom and any value is at most 8 bytes.
+/// A zero counter is stored as an empty atom.
 fn read_counter_u64(node: &StateValue<DefaultDB>) -> ChainResult<u64> {
     let bytes = cell_atom(node)?;
     if bytes.len() > 8 {
@@ -260,10 +201,8 @@ fn read_counter_u64(node: &StateValue<DefaultDB>) -> ChainResult<u64> {
     Ok(u64::from_le_bytes(le))
 }
 
-/// Read the `nonce` Counter from the Mailbox state and return it as a `u32`.
-/// This is the number of messages dispatched so far (valid dispatch keys are
-/// `0..nonce`), mirroring upstream `Mailbox.nonce`. The on-chain circuit caps
-/// the counter below `2^32`, so the cast cannot truncate a legitimate value.
+/// The number of messages dispatched so far. The on-chain circuit caps the
+/// counter below `2^32`, so the cast cannot truncate a legitimate value.
 pub fn decode_nonce_count(bytes: &[u8]) -> ChainResult<u32> {
     let cs = decode_contract_state(bytes)?;
     let root = cs.data.get_ref();
@@ -273,12 +212,8 @@ pub fn decode_nonce_count(bytes: &[u8]) -> ChainResult<u32> {
     })
 }
 
-/// Decode the append-only `dispatched_messages: Map<Uint<32>, Bytes<141>>`
-/// ledger field into `(nonce, message)` pairs sorted by nonce. Each map value
-/// is the wire-format encoded `HyperlaneMessage`; the decoder re-parses it and
-/// asserts the encoded nonce matches the map key — the same binding
-/// `Mailbox.recordDispatch` enforces on-chain, here as defence-in-depth
-/// against a malformed state read. Shared with the dispatch indexer (#16).
+/// Sorted by nonce. Each message's encoded nonce must match its map key, the
+/// same binding `Mailbox.recordDispatch` enforces on-chain.
 pub fn decode_dispatched_messages(bytes: &[u8]) -> ChainResult<Vec<(u32, HyperlaneMessage)>> {
     let cs = decode_contract_state(bytes)?;
     let root = cs.data.get_ref();
@@ -295,7 +230,7 @@ pub fn decode_dispatched_messages(bytes: &[u8]) -> ChainResult<Vec<(u32, Hyperla
     let mut out: Vec<(u32, HyperlaneMessage)> = Vec::with_capacity(map.size());
     for entry in map.iter() {
         let pair = &*entry;
-        // Map key is a little-endian `Uint<32>` nonce.
+        // The key is a little-endian `Uint<32>` nonce.
         let key_av = &*pair.0;
         let key_bytes = key_av
             .value
@@ -308,14 +243,9 @@ pub fn decode_dispatched_messages(bytes: &[u8]) -> ChainResult<Vec<(u32, Hyperla
         kb[..n].copy_from_slice(&key_bytes[..n]);
         let nonce = u32::from_le_bytes(kb);
 
-        // Map value is the wire-format encoded message. Compact trims trailing
-        // zero bytes from the stored `Bytes<141>` leaf, so a message whose tail
-        // is zero (e.g. a decimal-scaled amount ending in zero bytes — 10^17
-        // for a 6->18 decimal route ends in 0x0000) is stored as < 141 bytes.
-        // Right-pad back to the fixed width before decoding (the trimmed bytes
-        // were zeros); only an over-long value is an error. Mirrors
-        // `decode_single_message`. (The #15 simulator fixture used an identity
-        // scale, so its amount kept a non-zero tail and never triggered this.)
+        // Trailing zero bytes are trimmed on store, so a message whose tail is
+        // zero (a scaled amount ending in 0x00, say) comes back short and has
+        // to be right-padded before decoding.
         let value = cell_atom(&pair.1)?;
         if value.len() > ENCODED_MESSAGE_LEN {
             return Err(HyperlaneMidnightError::StateDecode(format!(
@@ -355,20 +285,15 @@ mod tests {
         <[u8; 20]>::try_from(v.as_slice()).unwrap()
     }
 
-    /// A `Cell` leaf wrapping the given `AlignedValue`-convertible value, as the
-    /// runtime stores scalar/byte ledger fields.
     fn cell<V: Into<AlignedValue>>(value: V) -> StateValue<DefaultDB> {
         StateValue::Cell(Sp::new(value.into()))
     }
 
-    /// Wrap a sequence of state values into a fixed-size `Array` node.
     fn array(values: Vec<StateValue<DefaultDB>>) -> StateValue<DefaultDB> {
         StateValue::Array(Array::from(values))
     }
 
-    /// Serialize a synthetic Mailbox `StateValue` tree into the same tagged
-    /// `ContractState` wire bytes the live indexer serves. The root mirrors the
-    /// deployed layout, with `Null` in the slots before each pinned field.
+    /// Produces the same tagged wire bytes the indexer serves.
     fn mailbox_state_bytes(
         deliveries: StateValue<DefaultDB>,
         nonce: StateValue<DefaultDB>,
@@ -407,7 +332,7 @@ mod tests {
             sender: H256::repeat_byte(0xAB),
             destination: 5678,
             recipient: H256::repeat_byte(0xCD),
-            // 64-byte body; trailing zeros exercise the right-pad path.
+            // Trailing zeros exercise the right-pad path.
             body: {
                 let mut b = vec![0u8; 64];
                 b[0] = 0x11;
@@ -429,7 +354,6 @@ mod tests {
 
     #[test]
     fn decodes_synthetic_nonce_count_zero() {
-        // A zero counter is stored as an empty atom (trailing zeros trimmed).
         let bytes = mailbox_state_bytes(
             StateValue::Map(HashMap::new()),
             cell(0u64),
@@ -440,9 +364,8 @@ mod tests {
 
     #[test]
     fn decodes_dispatched_messages_sorted_by_nonce() {
-        // Multiple map entries exercise the key parse + sort: the merkle
-        // reconstruction ingests leaves in nonce order, so a wrong key parse
-        // or ordering bug would produce a different root.
+        // The merkle reconstruction ingests leaves in nonce order, so a wrong
+        // key parse or ordering bug would produce a different root.
         let mut map = HashMap::<AlignedValue, StateValue<DefaultDB>, DefaultDB>::new();
         let mut expected = Vec::new();
         for nonce in [7u32, 0, 42, 1] {
@@ -464,18 +387,10 @@ mod tests {
 
     #[test]
     fn decode_dispatched_messages_right_pads_trimmed_value() {
-        // Regression for the merkle-hook / dispatch-indexer batch path
-        // (`decode_dispatched_messages`, used by
-        // `MidnightMerkleTreeHook::fetch_logs_in_range`). The runtime trims
-        // trailing zero bytes from a `Bytes<141>` leaf, so a real dispatch
-        // whose decimal-scaled amount ends in zero bytes is stored as < 141
-        // bytes (a 6->18-decimal route scales 10^5 to 10^17, which ends in
-        // 0x0000 -> a 139-byte on-chain value). This path previously asserted
-        // exactly 141 and rejected such messages with
-        // "dispatched message ... is 139 bytes, expected 141"; it must right-pad
-        // like the singular decoder. The #15 simulator fixture used an identity
-        // scale (non-zero amount tail -> full 141 bytes), so it never caught
-        // this. An all-zero body trims the most and pins the branch.
+        // A real dispatch whose scaled amount ends in zero bytes is stored
+        // shorter than 141 (a 6->18-decimal route scales 10^5 to 10^17, which
+        // ends in 0x0000). An all-zero body trims the most and pins the pad
+        // branch.
         let msg = HyperlaneMessage {
             version: 3,
             nonce: 0,
@@ -508,8 +423,7 @@ mod tests {
         );
     }
 
-    /// Serialize a synthetic ISM `StateValue` tree into the tagged
-    /// `ContractState` wire bytes, laid out so the pinned ISM paths line up.
+    /// Laid out so the ISM paths line up.
     fn ism_state_bytes(
         validators: StateValue<DefaultDB>,
         validator_count: u8,
@@ -535,12 +449,8 @@ mod tests {
         bytes
     }
 
-    /// Real secp256k1 keypair for the pubkey-registry tests: the 64-byte
-    /// registry value (X_be || Y_be, the uncompressed SEC1 body without the
-    /// 0x04 tag — exactly what the contract's `enrollValidator` stores) plus
-    /// the ETH address derived from it, cross-checked against ethers' own
-    /// independent secret-key -> address path so the derivation under test
-    /// cannot silently drift.
+    /// The derivation under test is cross-checked against ethers' own
+    /// key -> address path, so it cannot silently drift.
     fn validator_keypair(priv_hex: &str) -> ([u8; 64], [u8; 20]) {
         use ethers::core::k256::elliptic_curve::sec1::ToEncodedPoint;
         use ethers::core::k256::PublicKey;
@@ -550,16 +460,13 @@ mod tests {
         let point = PublicKey::from(&wallet.signer().verifying_key()).to_encoded_point(false);
         assert_eq!(point.as_bytes()[0], 0x04, "uncompressed SEC1 tag");
         let pubkey: [u8; 64] = point.as_bytes()[1..].try_into().unwrap();
-        // The registry-value -> identity derivation under test.
         let derived: [u8; 20] = ethers::utils::keccak256(pubkey)[12..].try_into().unwrap();
         assert_eq!(derived, wallet.address().0, "keccak256(pubkey)[12..]");
         (pubkey, derived)
     }
 
-    // The validators registry stores `Bytes<64>` secp256k1 pubkeys (#22);
-    // the decoder must derive each ETH address as `keccak256(pubkey)[12..]`
-    // and return them in ascending slot-index order regardless of the map's
-    // iteration order (entries are inserted out of order here).
+    // Addresses must come back in ascending slot-index order regardless of the
+    // map's iteration order, so the entries are inserted out of order here.
     #[test]
     fn decodes_synthetic_ism_state_from_pubkey_registry() {
         let (pk0, addr0) =
@@ -567,8 +474,6 @@ mod tests {
         let (pk1, addr1) =
             validator_keypair("2222222222222222222222222222222222222222222222222222222222222222");
 
-        // `validators: Map<Uint<8>, Bytes<64>>`, keyed by slot index; slot 1
-        // inserted first to exercise the sort-by-key ordering.
         let map = HashMap::<AlignedValue, StateValue<DefaultDB>, DefaultDB>::new()
             .insert(AlignedValue::from(1u8), cell(pk1))
             .insert(AlignedValue::from(0u8), cell(pk0));
@@ -585,18 +490,14 @@ mod tests {
         );
     }
 
-    // The runtime trims trailing zero bytes from a stored `Bytes<64>` leaf
-    // (`From<[u8; N]> for ValueAtom` drops them), so a pubkey whose Y
-    // coordinate ends in 0x00 is stored SHORT; `read_bytes64` must right-pad
-    // back to 64 before hashing, or such a validator (~1 in 256 keys) would
-    // fail to decode. Synthetic bytes rather than a real curve point — the
-    // decoder never validates the point, and forcing a zero tail pins the
-    // pad branch deterministically.
+    // A pubkey whose Y coordinate ends in 0x00 is stored short, and roughly
+    // one key in 256 does. Synthetic bytes rather than a real curve point: the
+    // decoder never validates the point, and a forced zero tail pins the pad
+    // branch.
     #[test]
     fn decodes_pubkey_with_trailing_zeros_trimmed_on_store() {
         let mut pubkey = [0x5Au8; 64];
         pubkey[61..].fill(0);
-        // Confirm the store actually trims, so this exercises the pad branch.
         assert_eq!(
             ValueAtom::from(pubkey).0.len(),
             61,
@@ -616,20 +517,12 @@ mod tests {
         );
     }
 
-    // Real `night` state captured from the local devnet indexer
-    // (deploy with validators 0x19e7../0x1563../0x5cbd.., threshold 2,
-    // module_type 5).
-    //
-    // IGNORED until the fixture is regenerated: this blob predates #22, so
-    // its `validators` map still stores 20-byte ETH addresses. The decoder
-    // now expects `Bytes<64>` secp256k1 pubkeys and derives the address via
-    // `keccak256(pubkey)[12..]`, so decoding the stale blob yields garbage
-    // addresses. Once the contracts repo regenerates `night-state.hex` from
-    // a deploy that enrolls the SAME three validator keys as 64-byte pubkeys,
-    // the derived addresses below are unchanged — drop the `#[ignore]`
-    // without touching the assertions.
+    // Real `night` state captured from a devnet indexer. Ignored because the
+    // committed blob predates the switch to 64-byte pubkey validators, so it
+    // decodes to garbage addresses. Regenerating it from a deploy of the same
+    // three keys leaves the assertions below valid.
     #[test]
-    #[ignore = "night-state.hex is a live-captured fixture predating #22 (32-byte validators) and the merkle-removal layout; regenerate from a fresh deploy of the same 3 validators — see contracts repo"]
+    #[ignore = "night-state.hex predates the 64-byte pubkey validator registry; regenerate from a fresh deploy of the same 3 validators"]
     fn decodes_live_night_ism_state() {
         let hex = include_str!("../tests/fixtures/night-state.hex").trim();
         let bytes = hex::decode(hex).expect("fixture is valid hex");

--- a/rust/main/chains/hyperlane-midnight/src/toolkit.rs
+++ b/rust/main/chains/hyperlane-midnight/src/toolkit.rs
@@ -9,12 +9,9 @@ use hyperlane_core::{ChainResult, HyperlaneMessage, H160, H256, H512, U256};
 
 use crate::HyperlaneMidnightError;
 
-/// How long an agent waits for the submitter subprocess to build a proof and
-/// land the tx — the relayer's `handle` submissions and the validator's
-/// self-announce alike. A real proof (multisig + ZK verify) can take many
-/// minutes on a RAM-constrained host, so this is overridable via
-/// `MIDNIGHT_SUBMIT_TIMEOUT_SECS` (default 120s) — mirrors the proof server's
-/// own `MIDNIGHT_PROOF_SERVER_JOB_TIMEOUT`.
+/// How long an agent waits for the submitter subprocess to prove and land a
+/// transaction. A real proof takes minutes on a RAM-constrained host, so
+/// `MIDNIGHT_SUBMIT_TIMEOUT_SECS` overrides the default.
 fn submit_timeout() -> Duration {
     Duration::from_secs(
         std::env::var("MIDNIGHT_SUBMIT_TIMEOUT_SECS")
@@ -25,142 +22,94 @@ fn submit_timeout() -> Duration {
 }
 const DELIVERED_TIMEOUT: Duration = Duration::from_secs(30);
 const STORAGE_LOCATIONS_TIMEOUT: Duration = Duration::from_secs(60);
-// Dry-run fetches state and executes `handle` locally (keccak/ecrecover
-// witnesses, no proving, no broadcast) — heavier than the `isDelivered`
-// read but far cheaper than a real submission.
 const DRY_RUN_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Maximum byte length of a storage location, matching the on-chain
-/// `Bytes<480>` buffer and the `MAX_STORAGE_LOCATION_LEN` circuit. A location
-/// longer than this is rejected before spawning the submitter.
+/// Matches the contract's `Bytes<480>` location buffer.
 pub const MAX_STORAGE_LOCATION_LEN: usize = 480;
 
-/// JSON payload for the `submit` op.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitRequest<'a> {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Deployed WarpRoute contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight node RPC endpoint.
     pub node_rpc_url: String,
-    /// Proof server endpoint.
     pub proof_server_url: String,
-    /// Midnight network id.
     pub network_id: String,
-    /// Hyperlane message.
     pub message: WireMessage<'a>,
-    /// MessageIdMultisigIsm metadata.
     pub metadata: WireMetadata,
-    /// Whether the recipient is a contract address.
     pub is_contract_recipient: bool,
 }
 
-/// Wire-format HyperlaneMessage.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WireMessage<'a> {
-    /// Hyperlane protocol version.
     pub version: u8,
     /// Origin-chain dispatch nonce (decimal string for JS BigInt safety).
     pub nonce: String,
-    /// Origin domain id.
     pub origin: u32,
-    /// `0x`-prefixed 32-byte hex.
     pub sender: String,
-    /// Destination domain id.
     pub destination: u32,
-    /// `0x`-prefixed 32-byte hex.
     pub recipient: String,
-    /// `0x`-prefixed 64-byte hex (TokenMessage payload).
     pub body: String,
     /// Avoids cloning the body bytes during serialization.
     #[serde(skip)]
     pub _marker: std::marker::PhantomData<&'a HyperlaneMessage>,
 }
 
-/// Wire-format ISM metadata.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WireMetadata {
-    /// Origin-chain merkle tree hook address.
     pub merkle_tree_hook: String,
-    /// Validator-signed merkle root.
     pub root: String,
-    /// Merkle tree index.
     pub index: u32,
-    /// Validator signatures — the real, quorum-sized set the metadata carried
-    /// (at most `MAX_VALIDATORS`), forwarded unpadded. The Midnight submitter
-    /// pads the on-chain `Vector<4>` by repeating slot 0.
+    /// Validator signatures, forwarded unpadded. The submitter pads the
+    /// on-chain `Vector<4>` by repeating slot 0.
     pub signatures: Vec<String>,
 }
 
-/// JSON payload for the `dryRunHandle` op — same message + metadata as
-/// `submit`, minus the node/proof endpoints (no transaction is built).
+/// Same message and metadata as `submit`, minus the node and proof endpoints:
+/// no transaction is built.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DryRunHandleRequest<'a> {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Deployed WarpRoute contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight network id.
     pub network_id: String,
-    /// Hyperlane message.
     pub message: WireMessage<'a>,
-    /// MessageIdMultisigIsm metadata.
     pub metadata: WireMetadata,
-    /// Whether the recipient is a contract address.
     pub is_contract_recipient: bool,
 }
 
-/// JSON envelope returned by the `dryRunHandle` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DryRunResponse {
-    /// `true` when the message would be accepted on-chain (no revert).
     #[serde(default)]
     pub ok: Option<bool>,
-    /// Structured error when the message would revert, or on a transport
-    /// failure talking to the indexer.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// JSON envelope returned by the `submit` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitResponse {
-    /// Transaction hash on success.
     #[serde(default)]
     pub tx_hash: Option<String>,
-    /// Block height on success.
     #[serde(default)]
     #[allow(dead_code)]
     pub block_height: Option<u64>,
-    /// DUST paid for the transaction, in specks (decimal string).
     #[serde(default)]
     pub fee_specks: Option<String>,
-    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Structured error from the submitter.
 #[derive(Debug, Deserialize)]
 pub struct SubmitError {
-    /// Short kind tag.
     pub kind: String,
-    /// Human-readable message.
     pub message: String,
 }
 
@@ -169,39 +118,28 @@ pub struct SubmitError {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BalanceRequest<'a> {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Expected wallet address, when known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<&'a str>,
 }
 
-/// JSON envelope returned by the `balance` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BalanceResponse {
-    /// Bech32m unshielded address of the sidecar wallet.
     #[serde(default)]
     pub address: Option<String>,
-    /// Spendable unshielded NIGHT in micro-units (decimal string).
     #[serde(default)]
     pub night_micro: Option<String>,
-    /// Generated DUST in specks at read time (decimal string).
     #[serde(default)]
     pub dust_specks: Option<String>,
-    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Balances of the sidecar's own wallet.
 #[derive(Debug, Clone)]
 pub struct WalletBalances {
-    /// Bech32m unshielded address the balances belong to.
     pub address: String,
-    /// Spendable unshielded NIGHT in micro-units.
     pub night_micro: U256,
-    /// Generated DUST in specks at read time.
     pub dust_specks: U256,
 }
 
@@ -253,31 +191,22 @@ pub async fn query_wallet_balance(
     })
 }
 
-/// Successful submission outcome.
 #[derive(Debug)]
 pub struct ToolkitOutcome {
     /// Transaction hash (Midnight 32 bytes packed into the low end of H512).
     pub transaction_id: H512,
-    /// Whether the contract reported success.
     pub executed: bool,
     /// DUST paid, in specks; `None` when the submitter omits the field.
     pub fee_specks: Option<U256>,
 }
 
-/// Runtime values needed at spawn time.
 #[derive(Debug, Clone)]
 pub struct ToolkitContext {
-    /// Path to the submitter binary.
     pub binary_path: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight node RPC endpoint.
     pub node_rpc_url: String,
-    /// Proof server endpoint.
     pub proof_server_url: String,
-    /// Midnight network id.
     pub network_id: String,
 }
 
@@ -314,7 +243,6 @@ fn derive_ws_url(http: &url::Url) -> String {
     ws.to_string()
 }
 
-/// Invoke the submitter for one message and return its outcome.
 pub async fn submit_handle(
     ctx: &ToolkitContext,
     request: &SubmitRequest<'_>,
@@ -383,37 +311,26 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-/// JSON payload for the `isDelivered` op.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IsDeliveredRequest {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Deployed WarpRoute contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight network id.
     pub network_id: String,
-    /// Message id to check.
     pub message_id: String,
 }
 
-/// JSON envelope returned by the `isDelivered` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IsDeliveredResponse {
-    /// Membership flag on success.
     #[serde(default)]
     pub delivered: Option<bool>,
-    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Query on-chain `deliveries` membership via the submitter.
 pub async fn query_delivered(
     ctx: &ToolkitContext,
     contract_address: H256,
@@ -421,10 +338,9 @@ pub async fn query_delivered(
 ) -> ChainResult<bool> {
     let request = IsDeliveredRequest {
         op: "isDelivered",
-        // Midnight contract addresses are bare hex — `@midnight-ntwrk/midnight-js-utils`
-        // throws TypeError on any leading `0x`. Hyperlane addresses elsewhere
-        // (EVM, Substrate, our own config parser) are `0x`-prefixed, so we
-        // strip only at the Midnight-SDK seam.
+        // Midnight contract addresses are bare hex; the SDK throws on a
+        // leading `0x`. Hyperlane addresses carry one everywhere else, so the
+        // prefix is stripped only at this seam.
         contract_address: format!("{contract_address:x}"),
         indexer_graphql_url: ctx.indexer_graphql_url.clone(),
         indexer_ws_url: ctx.indexer_ws_url.clone(),
@@ -456,45 +372,31 @@ pub async fn query_delivered(
         .map_err(Into::into)
 }
 
-/// JSON payload for the `announce` op (write tx).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnnounceRequest {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Deployed ValidatorAnnounce contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight node RPC endpoint.
     pub node_rpc_url: String,
-    /// Proof server endpoint.
     pub proof_server_url: String,
-    /// Midnight network id.
     pub network_id: String,
-    /// `0x`-prefixed 20-byte validator address.
     pub validator: String,
-    /// `0x`-prefixed hex of the FULL zero-padded `Bytes<480>` location buffer
-    /// — the exact bytes the validator signed over (#90). The submitter
-    /// forwards it verbatim; the on-chain digest hashes the padded buffer.
+    /// `0x`-prefixed hex of the whole zero-padded `Bytes<480>` buffer — the
+    /// exact bytes the validator signed over, since the on-chain digest hashes
+    /// the padding too.
     pub storage_location: String,
-    /// `0x`-prefixed 65-byte ECDSA signature (r || s || v).
     pub signature: String,
     /// `0x`-prefixed 64-byte secp256k1 public-key body (X_be || Y_be, no 0x04
-    /// SEC1 tag), recovered off-chain from the signature. Midnight's Compact
-    /// has no in-circuit ecrecover, so the verify-based `announce` circuit
-    /// takes the pubkey and derives the validator address from it (#90).
+    /// SEC1 tag), recovered off-chain. Compact has no in-circuit ecrecover, so
+    /// the `announce` circuit derives the validator address from the pubkey.
     pub pubkey: String,
 }
 
-/// Submit an `announce` write tx via the submitter. Expects `storage_location`
-/// to be the padded `MAX_STORAGE_LOCATION_LEN`-byte buffer the validator signed
-/// over (the shared validator agent pads before signing, #90) with a trailing
-/// NUL, and `pubkey` to be the 64-byte body recovered off-chain. Validates both
-/// before spawning the subprocess so the on-chain asserts never fire on input
-/// we can catch.
+/// Submit an `announce` write tx. Both the padded location buffer and the
+/// recovered pubkey are validated before spawning the subprocess, so the
+/// on-chain asserts never fire on input catchable here.
 pub async fn announce_tx(
     ctx: &ToolkitContext,
     contract_address: H256,
@@ -580,37 +482,26 @@ pub async fn announce_tx(
     })
 }
 
-/// JSON payload for the `getStorageLocations` op (read).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageLocationsRequest {
-    /// Operation discriminator.
     pub op: &'static str,
-    /// Deployed ValidatorAnnounce contract address.
     pub contract_address: String,
-    /// Indexer GraphQL endpoint (HTTP).
     pub indexer_graphql_url: String,
-    /// Indexer GraphQL endpoint (WebSocket).
     pub indexer_ws_url: String,
-    /// Midnight network id.
     pub network_id: String,
-    /// `0x`-prefixed 20-byte validator addresses to query.
     pub validators: Vec<String>,
 }
 
-/// JSON envelope returned by the `getStorageLocations` op.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageLocationsResponse {
-    /// One list of locations per requested validator, in request order.
     #[serde(default)]
     pub locations: Option<Vec<Vec<String>>>,
-    /// Structured error on failure.
     #[serde(default)]
     pub error: Option<SubmitError>,
 }
 
-/// Read announced storage locations for `validators` via the submitter.
 pub async fn query_storage_locations(
     ctx: &ToolkitContext,
     contract_address: H256,
@@ -661,11 +552,9 @@ pub async fn query_storage_locations(
         .into());
     }
 
-    // Defence-in-depth: the on-chain buffer is zero-padded to 480 bytes and the
-    // TS read op already trims at the first NUL, but trim again here so a padded
-    // string can never leak through — the validator agent compares the returned
-    // location against its own UNPADDED `announcement_location()` and would
-    // re-announce forever on a mismatch.
+    // The read op already trims at the first NUL, but trim again here: the
+    // validator compares this against its own unpadded location and would
+    // re-announce forever if padding leaked through.
     let trimmed = locations
         .into_iter()
         .map(|per_validator| {
@@ -746,8 +635,8 @@ async fn run_submitter<R: Serialize>(
 }
 
 /// Build the wire-format message shared by the `submit` and `dryRunHandle`
-/// payloads. `sender`/`recipient` keep the `0x` prefix (only the contract
-/// address is bare-hex at the Midnight-SDK seam — see `query_delivered`).
+/// payloads. Only the contract address is bare hex; everything else keeps its
+/// `0x` prefix.
 fn wire_message(message: &HyperlaneMessage) -> WireMessage<'_> {
     WireMessage {
         version: message.version,
@@ -761,7 +650,6 @@ fn wire_message(message: &HyperlaneMessage) -> WireMessage<'_> {
     }
 }
 
-/// Build a `SubmitRequest` from a HyperlaneMessage + metadata.
 pub fn build_request<'a>(
     contract_address: H256,
     ctx: &ToolkitContext,
@@ -784,9 +672,8 @@ pub fn build_request<'a>(
     }
 }
 
-/// Build a `DryRunHandleRequest` mirroring `build_request` so the dry-run
-/// executes exactly what `process` would submit — only the op and the
-/// absence of node/proof endpoints differ.
+/// Build a `DryRunHandleRequest` mirroring `build_request`, so the dry run
+/// executes exactly what `process` would submit.
 pub fn build_dry_run_request<'a>(
     contract_address: H256,
     ctx: &ToolkitContext,
@@ -806,12 +693,7 @@ pub fn build_dry_run_request<'a>(
     }
 }
 
-/// Dry-run `handle` against current chain state via the submitter, WITHOUT
-/// proving or submitting. `Ok(())` means the message would be accepted
-/// on-chain; `Err` means it would revert (mapped from the submitter's
-/// structured error) or the submitter failed. The relayer's
-/// `process_estimate_costs` uses this so a reverting message is caught at
-/// prepare time and backs off instead of busy-looping (issue #80).
+/// `Err` means the message would revert on-chain, or the submitter failed.
 pub async fn dry_run_handle(
     ctx: &ToolkitContext,
     request: &DryRunHandleRequest<'_>,
@@ -944,12 +826,8 @@ mod tests {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
-        // Mock submitter: echo a well-formed `getStorageLocations` envelope
-        // whose `locations` array has fewer entries than the validators we
-        // request. This guards the positional validator->location mapping:
-        // the results must line up with the requested order, so a length
-        // mismatch has to surface as a clear error rather than silently
-        // misaligning.
+        // The results are mapped to validators positionally, so a short
+        // `locations` array must error rather than silently misalign.
         let tmp = std::env::temp_dir().join(format!(
             "midnight-toolkit-locmismatch-{}.sh",
             std::process::id()
@@ -972,7 +850,6 @@ mod tests {
 
         let _ = std::fs::remove_file(&tmp);
 
-        // The guard reports the expected vs. actual list counts.
         let msg = format!("{err}");
         assert!(
             msg.contains("expected 2 location lists, got 1"),
@@ -1012,8 +889,8 @@ mod tests {
         assert!(display.contains("timeout") || display.contains("SIGKILL"));
     }
 
-    // Write an executable mock submitter that prints `json_response` on
-    // stdout, mirroring the inline scripts above. Caller removes the file.
+    // An executable mock submitter that prints `json_response` on stdout. The
+    // caller removes the file.
     fn write_mock_submitter(tag: &str, json_response: &str) -> std::path::PathBuf {
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
@@ -1047,13 +924,11 @@ mod tests {
         assert!(json.contains("\"op\":\"dryRunHandle\""));
         assert!(json.contains("\"version\":3"));
         assert!(json.contains("\"isContractRecipient\":false"));
-        // The dry-run payload omits the node/proof endpoints — no tx is built.
+        // No tx is built, so the node/proof endpoints are absent.
         assert!(!json.contains("nodeRpcUrl"));
         assert!(!json.contains("proofServerUrl"));
     }
 
-    // `{"ok":true}` -> the message would be accepted -> `Ok(())`, which the
-    // relayer reads as "gas estimate succeeded, proceed".
     #[tokio::test]
     async fn dry_run_ok_response_is_ok() {
         let script = write_mock_submitter("dryrun-ok", "{\"ok\":true}");
@@ -1066,8 +941,8 @@ mod tests {
         assert!(result.is_ok(), "expected Ok, got {result:?}");
     }
 
-    // A structured revert error -> `Err` carrying the kind + message, which
-    // the relayer turns into `ErrorEstimatingGas` -> exponential backoff.
+    // A revert must carry the kind and message through, since the relayer turns
+    // that into `ErrorEstimatingGas` and backs off.
     #[tokio::test]
     async fn dry_run_error_response_maps_to_submitter_reported() {
         let script = write_mock_submitter(
@@ -1091,8 +966,7 @@ mod tests {
         );
     }
 
-    // Neither `ok` nor `error` -> malformed. Defensive: the Node op always
-    // sends one or the other, so this only fires on a protocol drift.
+    // The op always sends one or the other, so this only fires on drift.
     #[tokio::test]
     async fn dry_run_missing_ok_and_error_is_malformed() {
         let script = write_mock_submitter("dryrun-empty", "{}");
@@ -1108,7 +982,4 @@ mod tests {
             "unexpected error: {display}"
         );
     }
-
-    // The submitter-timeout / SIGKILL path is shared with all ops via
-    // `run_submitter`, covered by `timeout_elapses_and_kills_child` above.
 }

--- a/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-midnight/src/validator_announce.rs
@@ -11,10 +11,9 @@ use hyperlane_core::{
 use crate::toolkit::{self, ToolkitContext};
 use crate::{ConnectionConf, MidnightProvider};
 
-/// ValidatorAnnounce backed by the on-chain Midnight ValidatorAnnounce
-/// contract. Reads go through a read-only submitter op (the on-chain
-/// `locations` map uses a `persistentHash` composite key the agent cannot
-/// reproduce); the write `announce` goes through a submitter tx op.
+/// ValidatorAnnounce backed by the on-chain Midnight contract. Even reads go
+/// through the submitter, because the `locations` map is keyed by a
+/// `persistentHash` composite the agent cannot reproduce.
 #[derive(Debug, Clone)]
 pub struct MidnightValidatorAnnounce {
     address: H256,
@@ -24,7 +23,7 @@ pub struct MidnightValidatorAnnounce {
 }
 
 impl MidnightValidatorAnnounce {
-    /// Build a new ValidatorAnnounce.
+    /// Construct a handle to the deployed contract.
     pub fn new(locator: &ContractLocator<'_>, conf: &ConnectionConf) -> ChainResult<Self> {
         let provider = MidnightProvider::from_conf(locator.domain.clone(), conf);
         let toolkit_ctx = ToolkitContext::from_conf(conf);
@@ -38,12 +37,8 @@ impl MidnightValidatorAnnounce {
     }
 }
 
-/// Recover the signer's secp256k1 public key from a 65-byte Ethereum signature
-/// (`r || s || v`) over `digest`, returning the 64-byte SEC1 uncompressed body
-/// (`X_be || Y_be`, no `0x04` tag) — exactly what the on-chain `announce`
-/// circuit takes as its `pubkey` param (#90). k256 is reached via `ethers`
-/// (already a dependency; the same crate `state_decode.rs` uses to derive
-/// addresses from stored pubkeys).
+/// Returns the 64-byte SEC1 body (`X_be || Y_be`, no `0x04` tag) that the
+/// on-chain `announce` circuit takes.
 fn recover_pubkey_body(digest: H256, sig65: &[u8; 65]) -> ChainResult<[u8; 64]> {
     use ethers::core::k256::ecdsa::{
         recoverable::{Id as RecoveryId, Signature as RecoverableSignature},
@@ -67,8 +62,8 @@ fn recover_pubkey_body(digest: H256, sig65: &[u8; 65]) -> ChainResult<[u8; 64]> 
             "announce: bad recoverable signature: {err}"
         ))
     })?;
-    // `digest` is the already-hashed EIP-191 announcement digest (the prehash
-    // the validator signed over), so recover directly from these bytes.
+    // `digest` is already the EIP-191 hash the validator signed, so recover
+    // straight from these bytes.
     let digest_bytes = digest.to_fixed_bytes();
     let vk = rsig
         .recover_verifying_key_from_digest_bytes(digest_bytes.as_ref().into())
@@ -79,7 +74,6 @@ fn recover_pubkey_body(digest: H256, sig65: &[u8; 65]) -> ChainResult<[u8; 64]> 
         })?;
     let point = vk.to_encoded_point(false);
     let bytes = point.as_bytes();
-    // Uncompressed SEC1 is 65 bytes: 0x04 || X(32) || Y(32).
     if bytes.len() != 65 {
         return Err(ChainCommunicationError::from_other_str(&format!(
             "announce: unexpected pubkey encoding length {}",
@@ -113,25 +107,19 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
         &self,
         validators: &[H256],
     ) -> ChainResult<Vec<Vec<String>>> {
-        // The on-chain validator key is the low 20 bytes of the H256 (the
-        // EVM-style address the pubkey derives to), matching the Aleo port and
-        // the `Bytes<20>` validator key on the contract.
+        // The contract keys validators by the low 20 bytes.
         let validators: Vec<H160> = validators.iter().map(|v| H160::from(*v)).collect();
         toolkit::query_storage_locations(&self.toolkit_ctx, self.address, &validators).await
     }
 
     async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
         let validator = announcement.value.validator;
-        // The validator agent has already padded this to the fixed 480-byte
-        // buffer for Midnight (`announcement_location`), which is what it signed
-        // over; forward it verbatim.
+        // The validator agent already padded this to the fixed 480-byte buffer
+        // it signed over, so forward it verbatim.
         let storage_location = announcement.value.storage_location.clone();
-        // `SignedType::signature` is a 65-byte ECDSA signature (r || s || v).
         let signature: [u8; 65] = announcement.signature.into();
-        // Midnight's Compact has no in-circuit ecrecover, so the verify-based
-        // `announce` circuit takes the signer's public key and derives the
-        // validator address from it (#90). Recover the pubkey off-chain from the
-        // EIP-191 announcement digest the validator signed.
+        // Compact has no in-circuit ecrecover, so the `announce` circuit takes
+        // the public key and derives the validator address from it.
         let digest = announcement.value.eth_signed_message_hash();
         let pubkey = recover_pubkey_body(digest, &signature)?;
 
@@ -148,8 +136,7 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
         Ok(TxOutcome {
             transaction_id: outcome.transaction_id,
             executed: outcome.executed,
-            // Gas is the DUST actually paid, in specks, at a unit price; zero
-            // when the submitter did not report a fee.
+            // Gas is the DUST actually paid, in specks, at a unit price.
             gas_used: outcome.fee_specks.unwrap_or_default(),
             gas_price: FixedPointNumber::from_str("1")
                 .map_err(|err| ChainCommunicationError::from_other_str(&err.to_string()))?,
@@ -161,12 +148,9 @@ impl ValidatorAnnounce for MidnightValidatorAnnounce {
         _announcement: SignedType<Announcement>,
         _chain_signer: H256,
     ) -> Option<U256> {
-        // Midnight fees are paid in DUST and are computed by the wallet inside
-        // the submitter subprocess (the Rust `MidnightSigner` is a
-        // placeholder), so the validator agent cannot pre-fund anything from
-        // here. `Some(0)` follows the Sealevel pattern: it signals "no extra
-        // tokens needed" rather than "unknown", so the validator agent proceeds
-        // to announce.
+        // Fees are DUST the wallet computes inside the submitter subprocess, so
+        // there is nothing the agent can pre-fund. `Some(0)` means "no extra
+        // tokens needed" rather than "unknown", so the announce proceeds.
         Some(U256::zero())
     }
 }
@@ -203,9 +187,7 @@ mod tests {
     }
 
     fn signature_from_bytes(bytes: [u8; 65]) -> Signature {
-        // `Signature` has no `From<[u8;65]>`; build it field-wise. The
-        // announce-path tests reject before the signature is ever decoded, so
-        // the exact value only matters for the round-trip test below.
+        // `Signature` has no `From<[u8; 65]>`, so build it field-wise.
         Signature {
             r: U256::from_big_endian(&bytes[0..32]),
             s: U256::from_big_endian(&bytes[32..64]),
@@ -232,8 +214,6 @@ mod tests {
 
     #[test]
     fn h256_to_h160_takes_low_20_bytes() {
-        // H160::from(H256) keeps the low 20 bytes — the EVM-style 20-byte
-        // validator address used on the contract.
         let mut raw = [0u8; 32];
         for (i, b) in raw.iter_mut().enumerate() {
             *b = i as u8;
@@ -252,11 +232,9 @@ mod tests {
         assert_eq!(needed, Some(U256::zero()));
     }
 
-    // A well-formed 65-byte signature over an arbitrary hash, so `announce`'s
-    // off-chain pubkey recovery succeeds and the location/pubkey validation in
-    // `announce_tx` is what a test exercises. The value it signs is irrelevant
-    // — recovery yields *some* pubkey and the length checks fire before it is
-    // ever used on-chain.
+    // A well-formed signature over an arbitrary hash, so pubkey recovery
+    // succeeds and the tests below reach the location validation. What it signs
+    // does not matter: recovery yields some pubkey either way.
     fn valid_sig() -> [u8; 65] {
         use ethers::signers::LocalWallet;
         let wallet: LocalWallet =
@@ -267,8 +245,7 @@ mod tests {
         <[u8; 65]>::from(sig)
     }
 
-    // Zero-pad a location into the fixed 480-byte buffer, as the validator agent
-    // does before signing.
+    // Zero-pad a location the way the validator agent does before signing.
     fn padded(location: &str) -> String {
         let mut bytes = location.as_bytes().to_vec();
         bytes.resize(toolkit::MAX_STORAGE_LOCATION_LEN, 0);
@@ -277,8 +254,6 @@ mod tests {
 
     #[tokio::test]
     async fn announce_rejects_non_480_location() {
-        // The fork expects the agent-padded 480-byte buffer; an unpadded
-        // location is rejected before the subprocess.
         let va = va("/usr/bin/true");
         let signed =
             signed_announcement(H160::repeat_byte(0x11), "s3://loc".to_string(), valid_sig());
@@ -292,7 +267,6 @@ mod tests {
 
     #[tokio::test]
     async fn announce_rejects_all_null_location() {
-        // A 480-byte buffer whose first byte is NUL is an empty location.
         let va = va("/usr/bin/true");
         let signed = signed_announcement(H160::repeat_byte(0x11), padded(""), valid_sig());
         let err = va.announce(signed).await.unwrap_err();
@@ -302,7 +276,7 @@ mod tests {
     #[tokio::test]
     async fn announce_rejects_location_with_no_trailing_nul() {
         // 480 meaningful bytes leave no terminator, so trim-on-read would be
-        // ill-defined; rejected.
+        // ill-defined.
         let va = va("/usr/bin/true");
         let full = "x".repeat(toolkit::MAX_STORAGE_LOCATION_LEN);
         let signed = signed_announcement(H160::repeat_byte(0x11), full, valid_sig());
@@ -312,8 +286,8 @@ mod tests {
 
     #[test]
     fn recover_pubkey_body_derives_validator() {
-        // The off-chain recovery must reproduce the validator address the way
-        // the circuit will on-chain: keccak256(X_be || Y_be)[12..] == validator.
+        // The off-chain recovery must reproduce the address the circuit derives
+        // on-chain: keccak256(X_be || Y_be)[12..].
         use ethers::signers::{LocalWallet, Signer};
         use ethers::utils::keccak256;
 
@@ -339,26 +313,19 @@ mod tests {
 
     #[tokio::test]
     async fn get_storage_locations_empty_input_returns_empty() {
-        // With no validators requested the submitter would echo an empty
-        // list; `/usr/bin/true` produces empty stdout which maps to a
-        // malformed-response error, so guard the empty-input path before any
-        // subprocess by asserting the request shape instead.
+        // An empty binary path short-circuits before any subprocess runs.
         let va = va("");
         let err = va
             .get_announced_storage_locations(&[H256::from_low_u64_be(1)])
             .await
             .unwrap_err();
-        // Empty binary path short-circuits to the missing-path error.
         assert!(format!("{err}").contains("not configured"));
     }
 
     #[tokio::test]
     async fn signed_announcement_signature_round_trips() {
-        // A real ECDSA-signed announcement keeps its 65-byte signature intact
-        // through the SignedType -> announce path, so the on-chain verify sees
-        // the exact bytes the validator produced. The agent never recomputes
-        // the digest (the validator signs, the contract verifies); this guards
-        // the pass-through.
+        // The agent never recomputes the digest, so the signature must reach
+        // the submitter byte-for-byte as the validator produced it.
         use ethers::signers::{LocalWallet, Signer};
 
         let wallet: LocalWallet =
@@ -372,9 +339,6 @@ mod tests {
             mailbox_domain: 1234,
             storage_location: "s3://hyperlane-validator-0/us-east-1".to_string(),
         };
-        // The validator signs the EIP-191 wrap of the announcement digest.
-        // `Wallet::sign_hash` applies no extra prefix, so this signs the exact
-        // 32-byte digest a Hyperlane validator would.
         let digest = announcement.eth_signed_message_hash();
         let sig = wallet.sign_hash(ethers::types::H256(digest.0));
         let sig_bytes: [u8; 65] = <[u8; 65]>::from(sig);
@@ -383,27 +347,7 @@ mod tests {
             value: announcement,
             signature: signature_from_bytes(sig_bytes),
         };
-        // Exactly what `announce()` extracts and forwards to the submitter.
         let forwarded: [u8; 65] = signed.signature.into();
         assert_eq!(forwarded, sig_bytes);
-    }
-
-    // End-to-end integration against a local devnet with a registered
-    // validator. Ignored by default: it needs a running Midnight devnet
-    // (proof server + node + indexer), the built `submit-handle` binary, and
-    // a deployed ValidatorAnnounce contract. Tracked as a follow-up — see the
-    // PR. Run with `cargo test -p hyperlane-midnight -- --ignored` once the
-    // devnet env vars (MIDNIGHT_NODE_RPC_URL, MIDNIGHT_PROOF_SERVER_URL,
-    // toolkitPath) and a deployed contract address are wired up.
-    #[tokio::test]
-    #[ignore = "requires a local devnet, the submit-handle binary, and a deployed VA contract"]
-    async fn announce_and_read_back_on_devnet() {
-        // 1. Build a MidnightValidatorAnnounce pointed at the deployed VA
-        //    contract address with a real toolkit_ctx (binary + endpoints).
-        // 2. Sign an announcement with a devnet validator key.
-        // 3. Call `announce(signed)` and assert the TxOutcome executed.
-        // 4. Call `get_announced_storage_locations(&[validator_h256])` and
-        //    assert the returned location matches what was announced.
-        unimplemented!("devnet integration test — see PR follow-up");
     }
 }

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
@@ -73,8 +73,6 @@ impl Indexable for InterchainGasPayment {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::RateLimited,
-            // Midnight gas payments are indexed from HYP_GAS_PAYMENT events
-            // over block ranges with no sequence, matching EVM (#95).
             HyperlaneDomainProtocol::Midnight => CursorType::RateLimited,
         }
     }
@@ -117,8 +115,6 @@ impl Indexable for Delivery {
             HyperlaneDomainProtocol::Radix => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Aleo => CursorType::SequenceAware,
             HyperlaneDomainProtocol::Tron => CursorType::RateLimited,
-            // Midnight deliveries are indexed from HYP_PROCESS events over
-            // block ranges with no sequence, matching EVM (#95).
             HyperlaneDomainProtocol::Midnight => CursorType::RateLimited,
         }
     }

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -395,8 +395,8 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // from_conf wires the submit sidecar so the wallet-balance
-                // metric can resolve through its `balance` op.
+                // `from_conf` also wires the sidecar, which is what answers the
+                // wallet-balance metric.
                 let provider =
                     h_midnight::MidnightProvider::from_conf(locator.domain.clone(), conf);
                 Ok(Box::new(provider) as Box<dyn HyperlaneProvider>)
@@ -570,8 +570,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // The monolithic WarpRoute embeds the merkle tree; read its
-                // count / current_root from chain state via the indexer (#14).
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
@@ -673,9 +671,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // Replays the WarpRoute contract's HYP_DISPATCH events over
-                // block ranges via the Midnight indexer's `contractEvents`
-                // query (#95); the `nonce` counter is the sequence tip.
                 let client =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let indexer = h_midnight::MidnightDispatchIndexer::new(client, &locator);
@@ -768,10 +763,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // Replays the WarpRoute contract's HYP_PROCESS events over
-                // block ranges via the Midnight indexer's `contractEvents`
-                // query (#95); driven by the rate-limited (watermark) cursor
-                // like EVM deliveries.
                 let client =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let indexer = h_midnight::MidnightDeliveryIndexer::new(client, &locator);
@@ -856,11 +847,8 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // The IGP indexer struct doubles as the paymaster marker
-                // (the Aleo/Radix/CosmosNative pattern). It reads the IGP
-                // contract's `gas_payments` state via the indexer client
-                // (#14); the relayer never calls the paymaster trait itself,
-                // but every configured chain must supply the boxed object.
+                // One struct serves as both the paymaster marker and the
+                // indexer, as on Aleo/Radix/CosmosNative.
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
@@ -953,10 +941,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // Replays the IGP contract's HYP_GAS_PAYMENT events over
-                // block ranges via the Midnight indexer's `contractEvents`
-                // query (#95); no sequence, matching EVM. Same struct as
-                // build_interchain_gas_paymaster above.
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
@@ -1098,9 +1082,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // Derives leaf insertions from the WarpRoute contract's
-                // HYP_DISPATCH events over block ranges (#95). Same struct as
-                // build_merkle_tree_hook above.
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
@@ -1281,8 +1262,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // The ISM reads its module type from chain state (via the
-                // indexer) on each `module_type` call, not from config.
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);
@@ -1360,8 +1339,6 @@ impl ChainConf {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(conf) => {
-                // Validators + threshold are read from chain state by the ISM
-                // itself (via the indexer), not sourced from config.
                 let indexer =
                     h_midnight::MidnightIndexerClient::new(conf.indexer_graphql_url.clone());
                 let provider = h_midnight::MidnightProvider::new(locator.domain.clone(), indexer);

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -239,8 +239,6 @@ fn parse_chain(
                 .and_then(|d| match d.domain_protocol() {
                     HyperlaneDomainProtocol::Ethereum => Some(IndexMode::Block),
                     HyperlaneDomainProtocol::Sealevel => Some(IndexMode::Sequence),
-                    // Midnight replays contract events over block ranges
-                    // (EVM-shaped indexing).
                     HyperlaneDomainProtocol::Midnight => Some(IndexMode::Block),
                     _ => None,
                 })
@@ -588,8 +586,8 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
         Some("cosmosKey") => parse_signer!(cosmosKey),
         Some("starkKey") => parse_signer!(starkKey),
         Some("radixKey") => parse_signer!(radixKey),
-        // The TS SDK's AgentSignerNodeSchema emits an explicit
-        // `{"type": "node"}`; accept it alongside the bare `{}` form.
+        // The TS SDK emits an explicit `{"type": "node"}`, so accept that
+        // alongside the bare `{}` form.
         Some("node") => Ok(SignerConf::Node),
         Some(t) => {
             Err(eyre!("Unknown signer type `{t}`")).into_config_result(|| (&signer.cwp).add("type"))

--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -616,8 +616,6 @@ impl HyperlaneDomain {
         use HyperlaneDomainProtocol::*;
         let protocol = self.domain_protocol();
         match protocol {
-            // Midnight indexes contract events over block ranges (the
-            // Midnight indexer's `contractEvents` query), like EVM.
             Ethereum | Cosmos | CosmosNative | Starknet | Tron | Midnight => IndexMode::Block,
             Fuel | Sealevel | Radix | Aleo => IndexMode::Sequence,
         }

--- a/rust/main/lander/src/adapter/chains/factory.rs
+++ b/rust/main/lander/src/adapter/chains/factory.rs
@@ -71,10 +71,8 @@ impl AdapterFactory {
             }
             #[cfg(feature = "midnight")]
             ChainConnectionConf::Midnight(_) => todo!(
-                "Issue #20: Midnight uses the Classic submitter by default. \
-                 This arm is only reached if a chain config explicitly sets `submitter: lander`. \
-                 If Lander support becomes desirable, implement `AdaptsChain` for Midnight here \
-                 (spawning `midnight-node-toolkit` as a subprocess)."
+                "Midnight uses the Classic submitter; this arm is only reached \
+                 if a chain config explicitly sets `submitter: lander`."
             ),
         };
         Ok(adapter)

--- a/typescript/cli/examples/midnight/core-config.yaml
+++ b/typescript/cli/examples/midnight/core-config.yaml
@@ -1,24 +1,19 @@
 # Midnight core deployment config for the local devnet e2e tests.
 #
-# The night contract is a monolith: the multisig ISM config below is sealed
-# into its constructor (validators/threshold rotate later via core apply),
-# merkleTreeHook resolves to the mailbox address itself, and the IGP deploys
-# as a standalone contract from the requiredHook slot (deploy-time input
-# only — read it back with `hyperlane hook read`).
+# The night contract is a monolith, so the ISM config below is sealed into its
+# constructor and the merkleTreeHook resolves to the mailbox address itself. The
+# IGP deploys as a standalone contract from requiredHook.
 #
-# Validators are the well-known anvil dev accounts #0-#2. Midnight enrolls
-# full secp256k1 public keys, so validatorPubkeys carries them; each entry
-# must keccak-derive to the matching validators address.
-#
-# owner 0x0 = the deployer keeps ownership (the on-chain owner is a
-# ZOwnablePK commitment that cannot be known before deploy).
+# A zero owner keeps ownership with the deployer.
 owner: '0x0000000000000000000000000000000000000000000000000000000000000000'
 defaultIsm:
   type: messageIdMultisigIsm
-  validators:
+  validators: # anvil dev accounts 0-2
     - '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
     - '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
     - '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
+  # Midnight enrolls full secp256k1 pubkeys; each must keccak-derive to its
+  # validator address above.
   validatorPubkeys:
     - '0x8318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed753547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5'
     - '0xba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0d67351e5f06073092499336ab0839ef8a521afd334e53807205fa2f08eec74f4'
@@ -31,8 +26,8 @@ requiredHook:
   owner: '0x0000000000000000000000000000000000000000000000000000000000000000'
   beneficiary: '0x0000000000000000000000000000000000000000000000000000000000000000'
   oracleKey: '0x0000000000000000000000000000000000000000000000000000000000000000'
-  # Added to the caller's gasLimit in every quote (destination mailbox + ISM
-  # processing cost). Stored on-chain alongside the oracle pair.
+  # Added to the caller's gasLimit in every quote, stored on-chain alongside
+  # the oracle pair.
   overhead:
     anvil2: 50000
   oracleConfig:

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -912,9 +912,8 @@ async function updateExistingWarpRoute(
 
   await promiseObjAll(
     objMap(expandedWarpDeployConfig, async (chain, config) => {
-      // Chains marked foreignDeployment supply reference data only (the
-      // router address and gas for remote enrollment); their deployment is
-      // managed elsewhere and must not be updated from this route.
+      // A foreignDeployment chain supplies reference data only; its deployment
+      // is managed elsewhere and must not be updated from this route.
       if (warpDeployConfig[chain]?.foreignDeployment) {
         logBlue(`Skipping foreign deployment chain ${chain}`);
         return;

--- a/typescript/cli/src/hook/read.ts
+++ b/typescript/cli/src/hook/read.ts
@@ -54,9 +54,9 @@ export async function readHookConfig({
       );
       const metadata = context.multiProvider.getChainMetadata(chain);
       const addresses = await context.registry.getChainAddresses(chain);
-      // MultiProvider structurally satisfies ChainLookup but its
-      // getChainName throws on unknown domains instead of returning null,
-      // which breaks the reader's skip-unknown-domain handling.
+      // MultiProvider structurally satisfies ChainLookup, but its
+      // `getChainName` throws on an unknown domain instead of returning null,
+      // which breaks the reader's skip handling.
       const hookReader = createHookReader(
         metadata,
         altVmChainLookup(context.multiProvider),

--- a/typescript/cli/src/tests/midnight/consts.ts
+++ b/typescript/cli/src/tests/midnight/consts.ts
@@ -20,9 +20,9 @@ export const HOOK_READ_CONFIG_PATH_1 = `${TEMP_PATH}/${CHAIN_NAME_1}/hook-config
 export const HOOK_APPLY_CONFIG_PATH_1 = `${TEMP_PATH}/${CHAIN_NAME_1}/hook-config-apply.yaml`;
 export const WARP_READ_OUTPUT_PATH_1 = `${TEMP_PATH}/${CHAIN_NAME_1}/warp-config-read.yaml`;
 
-// The signer's private state (owner nonces, maintenance signing keys) lives
-// here for the duration of a test run; e2e-test.setup.ts resets it together
-// with the chain addresses so every run starts from a fresh deploy.
+// Owner nonces and maintenance signing keys for the duration of a test run.
+// The setup hook resets this with the chain addresses, so every run starts from
+// a fresh deploy.
 export const MIDNIGHT_STATE_DIR = `${TEMP_PATH}/${CHAIN_NAME_1}/state`;
 
 // A remote domain for router-enrollment and gas-oracle entries. The chain
@@ -34,13 +34,11 @@ export const REMOTE_DOMAIN_ID = 31338;
 export const REMOTE_ROUTER_ADDRESS =
   '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266';
 
-// Ethereum key for the remote chain entry in warp deploy configs: chains
-// marked foreignDeployment are never written to, but the signer middleware
-// still requires a key for them. Anvil dev key #0.
+// Anvil dev key #0. The remote chain is never written to, but the signer
+// middleware still requires a key for it.
 export const REMOTE_HYP_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
-// Every state change on Midnight is a real proof: wallet balancing proofs
-// for deploys, circuit proofs for owner-gated updates. Minutes each, not
-// seconds — hence the dedicated timeout.
+// Every state change costs a real proof, which takes minutes rather than
+// seconds.
 export const MIDNIGHT_E2E_TEST_TIMEOUT = 1_200_000;

--- a/typescript/cli/src/tests/midnight/core/core-apply.e2e-test.ts
+++ b/typescript/cli/src/tests/midnight/core/core-apply.e2e-test.ts
@@ -41,12 +41,10 @@ describe('hyperlane midnight core apply e2e tests', async function () {
     ownerCommitment = coreConfig.owner;
   });
 
-  // Static multisig ISMs are immutable on EVM, but the night contract
-  // rotates validators in place via setValidatorsAndThreshold. The apply
-  // config mirrors the deploy config except: owner pinned to the on-chain
-  // commitment (avoids a spurious ownership transfer) and requiredHook as
-  // a plain address reference (the IGP block is deploy-time input only —
-  // repeating it here would deploy a second IGP).
+  // Mirrors the deploy config with two changes: the owner is pinned to the
+  // on-chain commitment, which avoids a spurious ownership transfer, and
+  // requiredHook is a plain address, since repeating the IGP block here would
+  // deploy a second IGP.
   function applyConfig(threshold: number): CoreConfig {
     const inputConfig: CoreConfig = readYamlOrJson(CORE_CONFIG_PATH);
     const ism = inputConfig.defaultIsm as MultisigIsmConfig;

--- a/typescript/cli/src/tests/midnight/e2e-test.setup.ts
+++ b/typescript/cli/src/tests/midnight/e2e-test.setup.ts
@@ -7,9 +7,8 @@ import {
   TEMP_PATH,
 } from './consts.js';
 
-// The devnet itself (node + indexer + proof server) is externally managed;
-// run-e2e-test.sh verifies it is reachable before mocha starts. This file
-// only resets the on-disk state so every run begins with a fresh deploy.
+// The devnet is externally managed and run-e2e-test.sh checks it is reachable
+// before mocha starts, so this only resets on-disk state.
 before(function () {
   if (fs.existsSync(CHAIN_1_ADDRESSES_PATH)) {
     fs.rmSync(CHAIN_1_ADDRESSES_PATH, { force: true });

--- a/typescript/cli/src/tests/midnight/run-e2e-test.sh
+++ b/typescript/cli/src/tests/midnight/run-e2e-test.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# Midnight e2e tests run against an externally managed local devnet: the
-# node, indexer, and proof server from the hyperlane-midnight repo's
-# docker compose, with contract size limits already raised (its devnet-up
-# script handles all of that). They also prove every state change for
-# real, which needs the full compiled contracts tree (prover keys are
-# multi-GB and are not packaged with the sdk).
+# These tests need an externally managed devnet (node, indexer, proof server)
+# and prove every state change for real, so they also need the full compiled
+# contracts tree: prover keys are multi-GB and are not packaged with the SDK.
 
 if [ -z "${HYPERLANE_MIDNIGHT_CONTRACTS}" ]; then
   echo "HYPERLANE_MIDNIGHT_CONTRACTS is not set."

--- a/typescript/cli/src/tests/midnight/warp/warp-apply-enroll.e2e-test.ts
+++ b/typescript/cli/src/tests/midnight/warp/warp-apply-enroll.e2e-test.ts
@@ -71,11 +71,9 @@ describe('hyperlane midnight warp apply e2e tests', async function () {
   function writeRouteConfigs(
     remoteRouters: Record<string, { address: string }>,
   ): void {
-    // The remote chain entry is reference data only (foreignDeployment):
-    // the CLI never submits there, but the signer middleware still wants a
-    // key for it — REMOTE_HYP_KEY satisfies that.
-    // Token metadata rides the config: non-EVM native entries are not
-    // derived from chain metadata by the shared token-metadata code.
+    // The remote entry is foreignDeployment reference data, but the signer
+    // middleware still wants a key for it. Token metadata has to be spelled out
+    // here too: non-EVM native entries derive nothing from chain metadata.
     const deployConfig: WarpRouteDeployConfig = {
       [CHAIN_NAME_1]: {
         type: TokenType.native,

--- a/typescript/cli/src/validator/preFlightCheck.ts
+++ b/typescript/cli/src/validator/preFlightCheck.ts
@@ -5,9 +5,8 @@ import { type Address, ProtocolType } from '@hyperlane-xyz/utils';
 import { type CommandContext } from '../context/types.js';
 import { errorRed, logBlue, logGreen, warnYellow } from '../logger.js';
 
-// Storage locations and the latest checkpoint index, resolved per protocol.
-// The merkle tree on Midnight lives off-chain (validators rebuild it from
-// dispatched messages), so the mailbox nonce stands in for the tree size.
+// Storage locations and the latest checkpoint index, per protocol. Midnight's
+// merkle tree lives off-chain, so the mailbox nonce stands in for the tree size.
 async function getOnChainValidatorState(
   context: CommandContext,
   chain: string,

--- a/typescript/deploy-sdk/src/ism/generic-ism-writer.ts
+++ b/typescript/deploy-sdk/src/ism/generic-ism-writer.ts
@@ -112,10 +112,9 @@ export class IsmWriter
 
   /**
    * Updates an existing ISM to match the desired configuration.
-   * Routing ISMs support updates (domain enrollment/unenrollment, owner
-   * changes). Multisig and test ISMs are immutable - returns empty array -
-   * unless the artifact manager reports in-place static updates, in which
-   * case the typed writer diffs current state and emits update transactions.
+   * Routing ISMs support updates. Multisig and test ISMs are immutable and
+   * return an empty array, unless the artifact manager reports in-place static
+   * updates, in which case the typed writer diffs and emits transactions.
    *
    * @param artifact The desired ISM state (must include deployed address)
    * @returns Array of transactions needed to perform the update

--- a/typescript/midnight-sdk/README.md
+++ b/typescript/midnight-sdk/README.md
@@ -7,6 +7,3 @@ Hyperlane CLI (`core`/`warp` `read`, `check`, `deploy`, `apply`, `send`).
 Midnight chain metadata carries two endpoint sets: `rpcUrls` point at the
 node, while `gatewayUrls` carry the indexer GraphQL endpoint, which is the
 read path for all chain state.
-
-Status: under construction. The provider read surface, signer, and artifact
-managers are being implemented incrementally.

--- a/typescript/midnight-sdk/scripts/generate-artifacts.js
+++ b/typescript/midnight-sdk/scripts/generate-artifacts.js
@@ -1,15 +1,8 @@
 /**
- * Populates ./artifacts with the compiled Compact contract modules the SDK
- * executes locally (state reads run circuits against fetched contract state;
- * deploys additionally need the verifier keys).
- *
- * Source resolution:
- *   1. HYPERLANE_MIDNIGHT_CONTRACTS env var — path to a compiled
- *      `contracts/src/managed` tree of the hyperlane-midnight repo.
- *   2. A sibling `hyperlane-midnight` checkout next to this monorepo.
- *
- * If neither source exists but ./artifacts is already populated, the
- * existing artifacts are kept (CI / clean-checkout builds).
+ * Populates ./artifacts with the compiled Compact contract modules the SDK runs
+ * locally. Sources them from `HYPERLANE_MIDNIGHT_CONTRACTS` or a sibling
+ * hyperlane-midnight checkout, and keeps whatever is already in ./artifacts if
+ * neither is present, so a clean CI checkout still builds.
  */
 import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -55,10 +48,9 @@ for (const name of CONTRACTS) {
   for (const file of ['index.js', 'index.d.ts']) {
     cpSync(resolve(contractSrc, file), resolve(dest, 'contract', file));
   }
-  // Verifier keys are only present on a full (non --skip-zk) compile and
-  // are small; prover keys and zkir circuits are multi-GB and stay in the
-  // compiled tree — proving flows point at it via HYPERLANE_MIDNIGHT_CONTRACTS
-  // at runtime instead of bundling.
+  // Verifier keys only exist after a full compile and are small. Prover keys
+  // and zkir circuits are multi-GB, so they stay in the compiled tree and
+  // proving flows point at it at runtime.
   const keysSrc = resolve(source, name, 'keys');
   if (existsSync(keysSrc)) {
     mkdirSync(resolve(dest, 'keys'), { recursive: true });
@@ -68,8 +60,7 @@ for (const name of CONTRACTS) {
       }
     }
   }
-  // midnight-js 5.0.0-beta.6 refuses ZK artifacts without the compiler's
-  // integrity manifest (compiler/contract-manifest.json).
+  // midnight-js refuses ZK artifacts without the compiler's integrity manifest.
   const compilerSrc = resolve(source, name, 'compiler');
   if (existsSync(compilerSrc)) {
     cpSync(compilerSrc, resolve(dest, 'compiler'), { recursive: true });

--- a/typescript/midnight-sdk/src/clients/protocol.ts
+++ b/typescript/midnight-sdk/src/clients/protocol.ts
@@ -48,7 +48,7 @@ export class MidnightProtocolProvider implements ProtocolProvider {
     _config: TConfig,
   ): Promise<ITransactionSubmitter> {
     throw new Error(
-      'MidnightProtocolProvider.createSubmitter: not implemented yet (#105)',
+      'MidnightProtocolProvider.createSubmitter: not implemented yet',
     );
   }
 

--- a/typescript/midnight-sdk/src/clients/provider.ts
+++ b/typescript/midnight-sdk/src/clients/provider.ts
@@ -38,8 +38,8 @@ export class MidnightProvider implements IProvider<MidnightTransaction> {
     protected readonly indexer: MidnightIndexerClient,
   ) {}
 
-  // Construction never dials the network, so a sync factory is safe; the
-  // async connect stays for the ProtocolProvider interface.
+  // Construction never dials the network, so a sync factory is safe; the async
+  // connect is only there for the interface.
   static fromMetadata(metadata: ChainMetadataForAltVM): MidnightProvider {
     const client = MidnightReadClient.fromMetadata(metadata);
     return new MidnightProvider(
@@ -104,10 +104,8 @@ export class MidnightProvider implements IProvider<MidnightTransaction> {
     return this.indexer.getBlockHeight();
   }
 
-  // Contract balances live on the ContractState balance map;
-  // queryUnshieldedBalances returns an empty list for contract addresses.
-  // Wallet (mn_...) addresses need a synced wallet, which the read-only
-  // provider does not have.
+  // Contract balances live on the ContractState balance map, since
+  // queryUnshieldedBalances returns nothing for a contract address.
   async getBalance(req: ReqGetBalance): Promise<bigint> {
     if (req.address.startsWith('mn')) {
       throw new Error(
@@ -145,10 +143,9 @@ export class MidnightProvider implements IProvider<MidnightTransaction> {
     return Boolean(result);
   }
 
-  // The night contract is a monolith: mailbox, ISM, hook, and warp token
+  // The night contract is a monolith, so mailbox, ISM, hook, and warp token all
   // share one address. Owner is the ZOwnablePK commitment, not a wallet
-  // address. Native NIGHT has no on-chain token metadata, so name/symbol
-  // come from chain metadata.
+  // address, and NIGHT's name/symbol come from chain metadata.
   async getToken(req: ReqGetToken): Promise<ResGetToken> {
     const state = await this.requireContractState(req.tokenAddress);
     const [owner, localDecimals] = await Promise.all([
@@ -243,9 +240,9 @@ export class MidnightProvider implements IProvider<MidnightTransaction> {
     return 0n;
   }
 
-  // Not part of IProvider; consumed by the SDK token adapter (aleo
-  // precedent). Builds the transferRemote call plus the payForGas
-  // follow-up the signer runs once the messageId is known.
+  // Not part of IProvider; the SDK token adapter calls it, following aleo.
+  // Builds the transferRemote call plus the payForGas follow-up the signer runs
+  // once the messageId is known.
   async getRemoteTransferTransaction(
     req: ReqRemoteTransfer,
   ): Promise<MidnightTransaction> {
@@ -284,9 +281,8 @@ export class MidnightProvider implements IProvider<MidnightTransaction> {
   }
 }
 
-// The balance map is keyed by TokenType objects, so get() by identity cannot
-// match; iterate and compare tag+raw against nativeToken() (the all-zeros
-// unshielded color).
+// The map is keyed by TokenType objects, so a `get()` by identity never
+// matches; compare tag and raw against `nativeToken()` instead.
 function readNativeBalance(balanceMap: unknown): bigint {
   if (!(balanceMap instanceof Map)) {
     return 0n;

--- a/typescript/midnight-sdk/src/clients/signer.ts
+++ b/typescript/midnight-sdk/src/clients/signer.ts
@@ -56,11 +56,10 @@ import { MidnightProvider } from './provider.js';
 import { MidnightReadClient } from './read-client.js';
 import { readGasPayments } from './state.js';
 
-// Proving is client-side in Midnight's architecture; public networks expose
-// no proof server, so the default is the operator's own local instance.
+// Proving is client-side and public networks expose no proof server, so the
+// default is the operator's own local instance.
 const DEFAULT_PROOF_SERVER_URL = 'http://127.0.0.1:6300';
-// Local private-state DB password (SDK enforces length/charset rules);
-// override via MIDNIGHT_STATE_PASSWORD.
+// Local private-state DB password; the SDK enforces length and charset rules.
 const DEFAULT_PRIVATE_STATE_PASSWORD = 'Hyperlane-Midnight-2026!';
 
 const PAY_FOR_GAS_ATTEMPTS = 3;
@@ -74,8 +73,8 @@ function errorText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// Rejects bad values rather than passing them on: Number('') is 0, which
-// disables the wait, and Number('abc') is NaN, which never reaches a deadline.
+// Rejects bad values rather than passing them on: `Number('')` is 0, which
+// disables the wait, and `Number('abc')` is NaN, which never hits a deadline.
 function payForGasSettleMs(): number {
   const raw = process.env.MIDNIGHT_PAY_FOR_GAS_SETTLE_MS;
   if (raw === undefined || raw.trim() === '') {
@@ -206,9 +205,9 @@ export class MidnightSigner
       blockHeight: Number(txData.public.blockHeight ?? 0),
     };
 
-    // transferRemote returns the dispatched messageId as its circuit
-    // result; the payForGas follow-up needs it, and core adapters read it
-    // off the receipt (there is no dispatch log to parse).
+    // transferRemote returns the dispatched messageId as its circuit result.
+    // The payForGas follow-up needs it, and core adapters read it off the
+    // receipt since there is no dispatch log to parse.
     const result = txData.private?.result;
     if (result instanceof Uint8Array && result.length === 32) {
       receipt.messageId = bytesToHex(result);
@@ -313,10 +312,10 @@ export class MidnightSigner
     }
   }
 
-  // Whether a failed payForGas attempt landed anyway. Polls, because the
-  // transaction may still be in flight when the confirmation wait gives up.
-  // Only a read from the end of the window can report the payment missing;
-  // an unreadable ledger rejects instead, since unknown is not missing.
+  // Whether a failed payForGas attempt landed anyway. It polls because the
+  // transaction may still be in flight when the confirmation wait gives up, and
+  // only a successful read at the end of the window can report it missing —
+  // unknown is not the same as missing.
   private async awaitLandedGasPayment(
     igpAddress: string,
     messageId: string,
@@ -329,8 +328,8 @@ export class MidnightSigner
       readFresh = false;
       const read = await this.readIgpState(igpAddress);
       if (read.ok) {
-        // Decoding is deliberately outside the read's error handling: a decode
-        // failure means the contract layout changed, which no retry fixes.
+        // Kept outside the read's error handling: a decode failure means the
+        // contract layout changed, which no retry fixes.
         const landed = findLandedGasPayment(
           readGasPayments(read.data),
           messageId,
@@ -371,8 +370,8 @@ export class MidnightSigner
     return super.getBalance(req);
   }
 
-  // Fees are paid in DUST, which the NIGHT balance never reflects. Reported
-  // in specks, DUST's atomic unit: 1 DUST = 10^15 specks.
+  // Fees are paid in DUST, which the NIGHT balance never reflects. Reported in
+  // specks: 1 DUST = 10^15 specks.
   async getFeeTokenBalance(req: ReqGetBalance): Promise<ResFeeTokenBalance> {
     if (req.address !== this.signerAddress) {
       throw new Error(
@@ -389,10 +388,8 @@ export class MidnightSigner
   }
 
   /**
-   * Deploy one of the compiled contracts. Computes the ZOwnablePK owner
-   * commitment from the wallet's shielded coinPublicKey plus the persisted
-   * (or freshly generated) per-contract secretNonce, then runs the deploy —
-   * chunked for the night monolith, single-shot otherwise.
+   * The ZOwnablePK owner commitment comes from the wallet's shielded
+   * coinPublicKey plus the per-contract secretNonce, persisted or generated.
    */
   async deployMidnightContract(options: {
     name: MidnightContractName;
@@ -436,8 +433,8 @@ export class MidnightSigner
       ownerStore: this.ownerStore,
       log,
     });
-    // The agents' index.from (chain metadata) must be at or before this;
-    // nothing else in the deploy flow surfaces the block.
+    // The agents' `index.from` must be at or before this, and nothing else in
+    // the deploy flow surfaces the block.
     const deployBlock = receipts[0]?.blockHeight;
     if (deployBlock) {
       log(`${options.name} deployed at block ${deployBlock}`);
@@ -459,9 +456,8 @@ export class MidnightSigner
     return this.walletPromise;
   }
 
-  // Fees are paid in DUST generated from registered NIGHT UTXOs. Registers
-  // unregistered UTXOs (idempotent) and waits for enough DUST to cover a
-  // fee; an empty wallet fails fast instead of waiting forever.
+  // Registers any unregistered NIGHT UTXOs and waits for enough DUST to cover
+  // a fee. An empty wallet fails fast rather than waiting forever.
   private async ensureFeesReady(ctx: WalletContext): Promise<void> {
     const state = await waitForSync(ctx);
     const dust = state.dust?.balance(new Date()) ?? 0n;
@@ -494,16 +490,16 @@ export class MidnightSigner
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly joinedContracts = new Map<string, Promise<any>>();
 
-  // Join a deployed contract for proven circuit calls. The stored private
-  // state (from a local deploy) wins over initialPrivateState; on a fresh
-  // machine the persisted owner-state nonce restores the owner identity.
+  // Join a deployed contract for proven circuit calls. Private state stored by
+  // a local deploy wins over `initialPrivateState`; on a fresh machine the
+  // persisted owner-state nonce restores the owner identity.
   private joinContract(
     name: MidnightContractName,
     rawContractAddress: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
-    // Registry configs carry 0x-prefixed addresses; the ledger's address
-    // parser rejects the prefix.
+    // Registry configs carry 0x-prefixed addresses, which the ledger's address
+    // parser rejects.
     const contractAddress = rawContractAddress.startsWith('0x')
       ? rawContractAddress.slice(2)
       : rawContractAddress;
@@ -539,9 +535,8 @@ export class MidnightSigner
   }
 }
 
-// Midnight writers need signer capabilities beyond the ISigner interface
-// (contract deploys, owner state); same downcast pattern as the other
-// protocol SDKs.
+// Midnight writers need capabilities beyond ISigner, like contract deploys and
+// owner state. Same downcast the other protocol SDKs use.
 export function requireMidnightSigner(signer: unknown): MidnightSigner {
   if (!(signer instanceof MidnightSigner)) {
     throw new Error(

--- a/typescript/midnight-sdk/src/deploy/chunked-deploy.ts
+++ b/typescript/midnight-sdk/src/deploy/chunked-deploy.ts
@@ -1,21 +1,13 @@
 /**
- * Chunked contract deploy, ported from hyperlane-midnight (#94): deploy
- * `night` with a minimal set of verifier keys, then add the remaining keys
- * in follow-up maintenance transactions so every tx stays under the chain's
- * per-block `bytes_written` budget. Stagenet's stock limits reject the
- * monolithic 30-circuit deploy (~51 KB of verifier keys; empirical
- * acceptance ceiling ~25 KB bytesWritten per tx), and raising them needs a
- * chain governance motion — chunking needs none.
+ * Chunked contract deploy: deploy `night` with a minimal set of verifier keys,
+ * then add the rest in follow-up maintenance transactions so every tx stays
+ * under the chain's per-block `bytes_written` budget. Stagenet's stock limits
+ * reject the monolithic deploy outright, and raising them needs a governance
+ * motion.
  *
- * Why this is hand-built at the ledger level instead of the SDK's
- * `addOrReplaceContractOperation` / `submitInsertVerifierKeyTx`:
- * compact-js 2.5.5-rc.6 hardcodes ledger operation version 'v3'
- * (`verifier-key[v6]`), which rejects compactc 0.33.0-rc.2 output
- * (`verifier-key[v7]` = version 'v4') before the tx is ever built.
- * Everything else — providers, wallet fee balancing, submission,
- * finalization watching — reuses the stock SDK via `submitTx`.
- * Maintenance updates carry no ZK proof; they are authorized purely by
- * the contract maintenance authority's signature.
+ * Built at the ledger level rather than through the SDK's insert helpers
+ * because compact-js pins ledger operation version 'v3' and rejects newer
+ * compiler output before the tx is even built.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -38,7 +30,6 @@ export function totalKeyBytes(entries: readonly VerifierKeyEntry[]): number {
   return entries.reduce((sum, e) => sum + e.key.length, 0);
 }
 
-/** Read every `keys/<circuit>.verifier` under a contract's artifacts dir. */
 export function readVerifierKeys(managedDir: string): VerifierKeyEntry[] {
   const keysDir = path.join(managedDir, 'keys');
   if (!fs.existsSync(keysDir)) {
@@ -59,8 +50,7 @@ export function readVerifierKeys(managedDir: string): VerifierKeyEntry[] {
     }));
 }
 
-// Circuits carried by the initial deploy tx itself (alongside the
-// constructor state): the bridge essentials, per the #94 scope.
+// Circuits carried by the initial deploy tx, alongside the constructor state.
 export const NIGHT_DEPLOY_CIRCUITS = [
   'handle',
   'transferRemote',
@@ -68,16 +58,12 @@ export const NIGHT_DEPLOY_CIRCUITS = [
   'enrollRemoteRouter',
 ] as const;
 
-// Every remaining exported circuit, in maintenance-insert priority order:
-// operator safety/admin first, then the verification/state surface the
-// agents read, then the sealed-config read views. The planner hard-fails
-// if this list and the compiled keys ever drift apart, so a night.compact
-// surface change must update it.
+// Every remaining circuit, in insert order. The planner fails if this drifts
+// from the compiled keys, so a contract surface change has to update it.
 //
-// Deploy-order safety: the constructor enrolls NO remote routers, so
-// `handle` / `transferRemote` reject everything until `enrollRemoteRouter`
-// is CALLED — enrollment comes after the last maintenance tx, making the
-// partially-populated window inert.
+// The partially-populated window is inert: the constructor enrolls no remote
+// routers, so `handle` and `transferRemote` reject everything until
+// `enrollRemoteRouter` is called after the last maintenance tx.
 export const NIGHT_MAINTENANCE_PRIORITY = [
   // admin & safety
   'pause',
@@ -112,11 +98,9 @@ export const NIGHT_MAINTENANCE_PRIORITY = [
   'isPaused',
 ] as const;
 
-// Default per-tx budget for RAW verifier-key bytes. Live stagenet
-// measurements (2026-07-16, node 2.0.0-rc.4 defaults): 24,885 bytesWritten
-// accepted, 33,522 rejected. The deploy tx adds ~7 KB of constructor state
-// and a maintenance tx only ~100 B of structure, so 18 KB of keys keeps
-// every tx comfortably under the observed ceiling.
+// Per-tx budget for raw verifier-key bytes. Stagenet accepted ~25 KB
+// bytesWritten and rejected ~33 KB, and the deploy tx carries another ~7 KB of
+// constructor state on top of the keys.
 export const DEFAULT_CHUNK_BUDGET_BYTES = 18_000;
 
 export interface ChunkPlan {
@@ -131,12 +115,6 @@ export interface ChunkPlanOptions {
   budgetBytes: number;
 }
 
-/**
- * Split a contract's verifier keys into the deploy set plus greedy
- * budget-packed maintenance batches that preserve `priority` order.
- * Fails loudly on any drift between the compiled keys and the plan
- * inputs, or on a single key exceeding the budget.
- */
 export function planChunks(
   entries: readonly VerifierKeyEntry[],
   options: ChunkPlanOptions,
@@ -213,14 +191,10 @@ export function planChunks(
 }
 
 /**
- * Subclass a generated contract constructor so only `circuitIds` remain in
- * `provableCircuits` AND in the initial contract state's operation table.
- * `deployContract` then fetches/embeds verifier keys for just that subset,
- * and the deploy tx carries no keyless operations — the node rejects those
- * with `MalformedError::VerifierKeyNotSet` (custom error 110). The other
- * entry points don't exist on-chain until a maintenance tx inserts them.
- * `circuits` / `impureCircuits` stay intact — call interfaces work as soon
- * as the matching key lands.
+ * Strips everything but `circuitIds` from `provableCircuits` and the initial
+ * state's operation table, so the deploy tx carries no keyless operations — the
+ * node rejects those with `VerifierKeyNotSet` (error 110). Call interfaces stay
+ * intact, so each entry point works as soon as its key lands.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function filteredContractClass<C extends new (...args: any[]) => any>(
@@ -260,11 +234,10 @@ export function filteredContractClass<C extends new (...args: any[]) => any>(
   };
 }
 
-// compactc's key files carry their ledger version in an ASCII header tag;
-// the ledger API names the enclosing ContractOperation slot one off from
-// the tag (verifier-key[v7] lives in the 'v4' slot). Sniffing the tag
-// (instead of hardcoding like compact-js does) keeps the builder honest
-// across compiler bumps — an unknown tag fails loudly.
+// Key files carry their ledger version in an ASCII header tag, and the ledger
+// API names the enclosing slot one off from that tag. Sniffing the tag rather
+// than hardcoding a version means an unknown one fails loudly on a compiler
+// bump instead of building a rejected tx.
 const KEY_TAG_TO_OPERATION_VERSION: Record<string, 'v3' | 'v4'> = {
   'midnight:verifier-key[v6]': 'v3',
   'midnight:verifier-key[v7]': 'v4',
@@ -284,10 +257,8 @@ export function operationVersionForKey(key: Uint8Array): 'v3' | 'v4' {
 }
 
 /**
- * Build, sign, and submit ONE maintenance tx inserting the batch's
- * verifier keys. Reads the maintenance-authority replay counter from the
- * CURRENT on-chain state, so batches must be submitted strictly
- * sequentially (each update bumps the counter by one).
+ * The replay counter is read from current chain state and each update bumps it,
+ * so batches have to be submitted strictly in sequence.
  */
 export async function insertVerifierKeys(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -325,8 +296,7 @@ export async function insertVerifierKeys(
     updates,
     counter,
   );
-  // deployContract creates a 1-of-1 authority from the sampled signing
-  // key, so a single signature at committee index 0 carries the update.
+  // The authority is 1-of-1, so one signature at committee index 0 carries it.
   const signed = unsigned.addSignature(
     0n,
     ledger.signData(signingKey, unsigned.dataToSign),
@@ -335,8 +305,7 @@ export async function insertVerifierKeys(
   const intent = ledger.Intent.new(
     new Date(Date.now() + 60 * 60 * 1000),
   ).addMaintenanceUpdate(signed);
-  // Maintenance updates sit in the fallible segment; guaranteed/fallible
-  // coin offers stay empty and the wallet's balanceTx adds the fee dust.
+  // Both coin offers stay empty; the wallet's balanceTx adds the fee dust.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const unprovenTx = (ledger.Transaction as any).fromParts(
     getNetworkId(),
@@ -349,10 +318,8 @@ export async function insertVerifierKeys(
 }
 
 /**
- * Assert every compiled verifier key is present and byte-identical in the
- * CURRENT on-chain contract state. Mirrors the SDK check that
- * `findDeployedContract` runs, so a contract passing here is joinable by
- * any caller with the full compiled artifact.
+ * The same check `findDeployedContract` runs, so a contract passing here is
+ * joinable by any caller holding the full artifact.
  */
 export async function verifyFullSurface(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/typescript/midnight-sdk/src/deploy/deploy-contract.ts
+++ b/typescript/midnight-sdk/src/deploy/deploy-contract.ts
@@ -26,10 +26,9 @@ import {
 import type { OwnerStateStore } from './owner-state.js';
 import type { ContractProviders } from './providers.js';
 
-// The packaged artifacts carry the contract module + verifier keys only.
-// Proving (deploys, circuit calls) additionally needs the multi-GB prover
-// keys and zkir circuits, which stay in a compiled hyperlane-midnight tree
-// pointed at via HYPERLANE_MIDNIGHT_CONTRACTS.
+// The packaged artifacts hold the contract module and verifier keys only.
+// Proving also needs the multi-GB prover keys and zkir circuits, which stay in
+// a compiled contracts tree that `HYPERLANE_MIDNIGHT_CONTRACTS` points at.
 export function artifactsPathFor(name: MidnightContractName): string {
   const compiled = process.env.HYPERLANE_MIDNIGHT_CONTRACTS;
   if (compiled) {
@@ -111,10 +110,9 @@ export async function deployContractInstance(
   ];
   log(`${name} deployed at ${address}`);
 
-  // Keep a visible, backupable copy of the maintenance-authority signing
-  // key the SDK sampled at deploy time — the level private-state DB is its
-  // only other home, and without the key no verifier key can ever be added
-  // or replaced on this instance again.
+  // A visible, backupable copy of the maintenance-authority signing key: its
+  // only other home is the level private-state DB, and losing it means no
+  // verifier key can ever be added or replaced on this instance again.
   const signingKey: unknown =
     await req.providers.privateStateProvider.getSigningKey(address);
   if (signingKey != null) {

--- a/typescript/midnight-sdk/src/deploy/owner-state.ts
+++ b/typescript/midnight-sdk/src/deploy/owner-state.ts
@@ -1,11 +1,9 @@
 /**
- * Per-contract owner state, ported from hyperlane-midnight. The ZOwnablePK
- * substrate binds the owner id to `secretNonce` (private state) +
- * `instanceSalt` (constructor immutable). Both are generated once per
- * contract and persisted so admin tooling can use the same identity later.
- * The maintenance-authority signing key sampled at deploy time is persisted
- * too — losing it means never being able to add or replace verifier keys
- * on that contract instance again.
+ * Per-contract owner state. ZOwnablePK binds the owner id to a `secretNonce` in
+ * private state plus an immutable `instanceSalt`, both generated once per
+ * contract and persisted so admin tooling keeps the same identity later. The
+ * maintenance-authority signing key is persisted too: losing it means never
+ * being able to add or replace verifier keys on that instance again.
  */
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';

--- a/typescript/midnight-sdk/src/deploy/providers.ts
+++ b/typescript/midnight-sdk/src/deploy/providers.ts
@@ -11,9 +11,9 @@ import {
 
 export interface ProviderOptions {
   endpoints: WalletEndpoints;
-  // Absolute path of the level DB directory. This must be midnightDbName —
-  // the provider's privateStateStoreName option is only a sublevel name
-  // inside the DB, and the DB itself would land in the process cwd.
+  // Absolute path of the level DB directory, which must be `midnightDbName`:
+  // `privateStateStoreName` only names a sublevel inside the DB, so the DB
+  // itself would otherwise land in the process cwd.
   privateStateDbPath: string;
   privateStatePassword: string;
 }
@@ -22,9 +22,9 @@ export interface ProviderOptions {
 export type ContractProviders = any;
 
 /**
- * Build the provider bundle that `deployContract` / `findDeployedContract`
- * consume. `zkConfigPath` points to the per-contract artifacts dir so the
- * zk-config provider can locate prover/verifier keys.
+ * Build the provider bundle `deployContract` and `findDeployedContract`
+ * consume. `zkConfigPath` is the per-contract artifacts dir holding the
+ * prover/verifier keys.
  */
 export async function createProviders(
   walletCtx: WalletContext,
@@ -37,10 +37,8 @@ export async function createProviders(
   }
   const shielded = state.shielded;
 
-  // CAST: `balanceTx` and `submitTx` straddle two SDK packages —
-  // midnight-js-contracts types its provider's tx parameters against
-  // classes that aren't nominally compatible with the wallet-sdk's. The
-  // runtime contract holds; the types don't reconcile across packages.
+  // `balanceTx` and `submitTx` straddle two SDK packages whose tx types are not
+  // nominally compatible. The runtime shapes match; the types do not.
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const walletProvider = {
     getCoinPublicKey: () => shielded.coinPublicKey.toHexString(),
@@ -59,10 +57,8 @@ export async function createProviders(
         },
         { ttl: ttl ?? new Date(Date.now() + 30 * 60 * 1000) },
       );
-      // signRecipe signs the unshielded-offer inputs that any
-      // `receiveUnshielded`-using circuit produces (e.g. `night.fund`).
-      // Without it the chain rejects with
-      // `MalformedError::InputsSignaturesLengthMismatch` (error 192).
+      // Signs the unshielded-offer inputs any `receiveUnshielded` circuit
+      // produces; without it the chain rejects with error 192.
       const signed = await walletCtx.wallet.signRecipe(recipe, (payload) =>
         walletCtx.unshieldedKeystore.signDataAsync(payload),
       );

--- a/typescript/midnight-sdk/src/deploy/wallet.ts
+++ b/typescript/midnight-sdk/src/deploy/wallet.ts
@@ -1,8 +1,7 @@
 /**
- * Deployer wallet construction, ported from hyperlane-midnight. Builds the
- * WalletFacade (shielded + unshielded + dust sub-wallets) from an HD seed;
- * the unshielded keystore signs unshielded-offer inputs and pays fees in
- * DUST generated from registered NIGHT UTXOs.
+ * Builds the WalletFacade (shielded, unshielded, and dust sub-wallets) from an
+ * HD seed. The unshielded keystore signs unshielded-offer inputs and pays fees
+ * in DUST generated from registered NIGHT UTXOs.
  */
 import * as Rx from 'rxjs';
 import { WebSocket } from 'ws';
@@ -24,9 +23,9 @@ import {
 } from '@midnightntwrk/wallet-sdk';
 import type { UnshieldedAddress } from '@midnightntwrk/wallet-sdk';
 
-// Wallet SDK uses a global WebSocket to drive indexer GraphQL
-// subscriptions; Node has no DOM-style WebSocket so we polyfill from `ws`.
-// @ts-expect-error — DOM WebSocket vs `ws` types differ but the runtime contract holds.
+// The wallet SDK drives indexer subscriptions off a global WebSocket, which
+// Node does not have.
+// @ts-expect-error — DOM WebSocket vs `ws` types differ but the runtime agrees.
 globalThis.WebSocket ??= WebSocket;
 
 export interface WalletEndpoints {
@@ -37,10 +36,9 @@ export interface WalletEndpoints {
 }
 
 /**
- * The dust sub-wallet adds this to every fee it computes (`costParameters`
- * below), so a wallet holding less DUST than this cannot balance any
- * transaction. It is a floor, not a fee estimate: a large deploy needs more,
- * and MIDNIGHT_MIN_DUST_SPECKS raises the bar.
+ * The dust sub-wallet adds this to every fee it computes, so a wallet holding
+ * less cannot balance any transaction at all. It is a floor, not an estimate: a
+ * large deploy needs more, and `MIDNIGHT_MIN_DUST_SPECKS` raises the bar.
  */
 const DUST_FEE_OVERHEAD_SPECKS = 300_000_000_000_000n;
 
@@ -76,9 +74,9 @@ export function deriveKeys(seedHex: string) {
 }
 
 /**
- * Derive the unshielded (NightExternal role) keystore alone — enough for a
- * synchronous signer address without starting or syncing a full wallet.
- * `setNetworkId` must have been called first.
+ * Derive just the unshielded keystore, which is enough for a synchronous signer
+ * address without starting or syncing a full wallet. `setNetworkId` must have
+ * been called first.
  */
 export function deriveUnshieldedKeystore(seedHex: string) {
   const keys = deriveKeys(seedHex);
@@ -102,9 +100,8 @@ export async function createWallet(
     networkId,
   );
 
-  // wallet-sdk beta.2 reads `configuration.txHistoryStorage` at the FACADE
-  // level; without it post-submit bookkeeping throws. Shared with the
-  // unshielded sub-wallet below.
+  // Read at the facade level, not just per sub-wallet: without it here,
+  // post-submit bookkeeping throws.
   const txHistoryStorage = new InMemoryTransactionHistoryStorage(
     WalletEntrySchema,
     mergeWalletEntries,
@@ -119,17 +116,15 @@ export async function createWallet(
     provingServerUrl: new URL(endpoints.proofServer),
     relayURL: new URL(endpoints.node.replace(/^http/, 'ws')),
     txHistoryStorage,
-    // CAST: `DefaultConfiguration` requires fields the SDK accepts as a
-    // partial structure at runtime via per-sub-wallet configuration
-    // callbacks.
+    // `DefaultConfiguration` demands fields the SDK actually accepts as a
+    // partial structure, filled in by the sub-wallet callbacks below.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 
   const wallet = await WalletFacade.init({
     configuration: walletConfig,
-    // CASTs below bridge nested SDK-internal copies of types that don't
-    // reconcile nominally with the top-level exports; one published SDK,
-    // identical runtime shapes.
+    // The casts bridge nested SDK-internal copies of types that do not
+    // reconcile with the top-level exports, despite identical runtime shapes.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     shielded: (config) =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -147,8 +142,7 @@ export async function createWallet(
     dust: (config) =>
       DustWallet({
         ...config,
-        // Fee headroom defaults; tx generation hits these when DUST is
-        // tight on a fresh wallet.
+        // Fee headroom, which tx generation hits on a fresh wallet.
         costParameters: {
           additionalFeeOverhead: DUST_FEE_OVERHEAD_SPECKS,
           feeBlocksMargin: 5,
@@ -168,8 +162,8 @@ export async function closeWallet(ctx: WalletContext): Promise<void> {
   await ctx.wallet.stop();
 }
 
-// WalletFacade.state() emits a complex generic type the wallet-sdk doesn't
-// export cleanly; treat the state object as a structural subset.
+// `WalletFacade.state()` emits a generic the SDK does not export cleanly, so
+// this is a structural subset of it.
 export interface WalletState {
   isSynced: boolean;
   shielded?: { coinPublicKey: { toHexString(): string } };
@@ -212,11 +206,10 @@ export async function getUnshieldedAddress(
 }
 
 /**
- * Throw unless the wallet holds enough DUST to pay a fee.
- *
- * NIGHT generates DUST at a fixed rate per unit held, up to a cap also
- * proportional to NIGHT, so an operator short of DUST either waits or funds
- * more NIGHT. The error reports both so they can tell which.
+ * Throw unless the wallet holds enough DUST to pay a fee. NIGHT generates DUST
+ * at a fixed rate up to a cap, both proportional to the amount held, so someone
+ * short of DUST either waits or funds more NIGHT — the error reports both rates
+ * so they can tell which.
  */
 export async function assertDustForFees(ctx: WalletContext): Promise<void> {
   const state = await waitForSync(ctx);
@@ -240,8 +233,8 @@ export async function assertDustForFees(ctx: WalletContext): Promise<void> {
 
 /**
  * Register the wallet's unregistered NIGHT UTXOs for DUST generation.
- * Idempotent. Registration only starts generation, so this still throws when
- * the balance is short: DUST accrues over time, not on submission.
+ * Idempotent, and still throws when the balance is short: registration only
+ * starts generation, and DUST accrues over time rather than on submission.
  */
 export async function registerNightForDust(ctx: WalletContext): Promise<void> {
   const state = await waitForSync(ctx);
@@ -251,8 +244,8 @@ export async function registerNightForDust(ctx: WalletContext): Promise<void> {
   );
 
   if (unregistered.length > 0) {
-    // The synced state's coins are a structural view; the facade wants its
-    // own UtxoWithMeta. Same shape, distinct declaration.
+    // The synced state's coins are a structural view of the facade's own
+    // UtxoWithMeta: same shape, separate declaration.
     const recipe = await ctx.wallet.registerNightUtxosForDustGeneration(
       unregistered as unknown as Parameters<
         typeof ctx.wallet.registerNightUtxosForDustGeneration

--- a/typescript/midnight-sdk/src/hook/hook-artifact-manager.ts
+++ b/typescript/midnight-sdk/src/hook/hook-artifact-manager.ts
@@ -27,11 +27,10 @@ import { MidnightReadClient } from '../clients/read-client.js';
 import { MidnightSigner, requireMidnightSigner } from '../clients/signer.js';
 import { readRemoteGasData, topLevelArity } from '../clients/state.js';
 
-// Midnight has no dispatch-coupled hooks. This manager exists because the
-// CLI's data model carries two things as "hooks": the checkpoint format's
-// merkle_tree_hook identity (the night address — the tree itself is rebuilt
-// off-chain by validators) and the IGP config (the IGP is a standalone
-// contract here; gas payment is a separate, decoupled transaction).
+// Midnight has no dispatch-coupled hooks. This manager exists because the CLI
+// models two other things as hooks: the checkpoint format's merkle_tree_hook
+// identity, and the IGP, which here is a standalone contract paid in a separate
+// transaction.
 const NIGHT_STATE_ARITY = 2;
 const IGP_STATE_ARITY = 8;
 
@@ -169,10 +168,9 @@ class MidnightIgpHookWriter
     const deployResult = await this.signer.deployMidnightContract({
       name: 'igp',
       buildArgs: ({ ownerId, instanceSalt, deployerUnshielded }) => {
-        // The sealed `claim` beneficiary. Config values are treated as
-        // unshielded user addresses; absent/zero falls back to the
-        // deployer's own unshielded address. Re-pointable later via
-        // setBeneficiary.
+        // The sealed `claim` beneficiary, treated as an unshielded user
+        // address. Falls back to the deployer's own, and `setBeneficiary`
+        // re-points it later.
         const beneficiary = resolveBeneficiaryBytes(
           config.beneficiary,
           deployerUnshielded,

--- a/typescript/midnight-sdk/src/ism/ism-artifact-manager.ts
+++ b/typescript/midnight-sdk/src/ism/ism-artifact-manager.ts
@@ -88,12 +88,11 @@ class MidnightMultisigIsmWriter
       DeployedIsmAddress
     >
 {
-  // The ISM is a facet of the night monolith and cannot deploy standalone:
-  // validators/threshold are night constructor args, and the contract does
-  // not exist yet when the core deploy orchestrator asks for the ISM. The
-  // returned zero-address sentinel keeps the config flowing to the mailbox
-  // writer, which seals it into the constructor and stamps the real (night)
-  // address back on this artifact once it is known.
+  // The ISM is a facet of the night monolith and cannot deploy standalone: its
+  // validators and threshold are constructor args, and the contract does not
+  // exist yet when the orchestrator asks. The zero-address sentinel keeps the
+  // config flowing to the mailbox writer, which seals it in and stamps the real
+  // address back here.
   async create(
     artifact: ArtifactNew<RawIsmArtifactConfigs['messageIdMultisigIsm']>,
   ): Promise<

--- a/typescript/midnight-sdk/src/ism/validators.ts
+++ b/typescript/midnight-sdk/src/ism/validators.ts
@@ -27,10 +27,9 @@ export interface ResolvedValidatorSet {
 }
 
 /**
- * Resolve the 64-byte validator pubkeys a Midnight write needs from a
- * multisig ISM config. `validators` carries the canonical eth addresses
- * (what reads and checks compare); `validatorPubkeys` must accompany them
- * for writes, and each pubkey must hash to its validator address.
+ * `validators` holds the canonical eth addresses that reads and checks compare
+ * against; a write additionally needs `validatorPubkeys`, each of which must
+ * hash to its address.
  */
 export function resolveValidatorSet(
   config: RawIsmArtifactConfigs['messageIdMultisigIsm'],

--- a/typescript/midnight-sdk/src/mailbox/mailbox-artifact-manager.ts
+++ b/typescript/midnight-sdk/src/mailbox/mailbox-artifact-manager.ts
@@ -27,9 +27,9 @@ import { MidnightReadClient } from '../clients/read-client.js';
 import { MidnightSigner, requireMidnightSigner } from '../clients/signer.js';
 import { resolveValidatorSet } from '../ism/validators.js';
 
-// Wire-format precision of warp transfer amounts (the max decimals in the
-// route), NOT the remote chain's local token decimals. See the Scale
-// module in hyperlane-midnight before changing this.
+// Wire-format precision of warp transfer amounts, meaning the max decimals in
+// the route rather than the remote chain's local token decimals. Check the
+// contracts repo's Scale module before changing this.
 const MESSAGE_DECIMALS = 18n;
 
 class MidnightMailboxReader implements ArtifactReader<
@@ -44,12 +44,10 @@ class MidnightMailboxReader implements ArtifactReader<
       this.client.runCircuit<Uint8Array>('night', state.data, 'owner'),
       this.client.runCircuit<bigint>('night', state.data, 'localDomain'),
     ]);
-    // The night contract is a monolith and is its own default ISM. Midnight
-    // has no dispatch-coupled hooks: the merkle tree lives off-chain
-    // (validators rebuild it from dispatched_messages), and the night
-    // address fills the checkpoint format's merkle_tree_hook slot — so the
-    // "defaultHook" here is that protocol identity, not a contract. There
-    // is no required hook.
+    // The night contract is a monolith and its own default ISM. There are no
+    // dispatch-coupled hooks here, so `defaultHook` is the merkle_tree_hook
+    // identity the checkpoint format wants, not a contract, and nothing fills
+    // the required hook.
     const self = {
       artifactState: ArtifactState.UNDERIVED,
       deployed: { address },
@@ -82,11 +80,10 @@ class MidnightMailboxWriter
     super(client);
   }
 
-  // Deploys the night monolith (mailbox + ISM + native warp route in one
-  // contract). The multisig ISM config is consumed here: validators,
-  // threshold, and decimals are night constructor args, sealed at deploy
-  // time. Hook placeholders from the orchestrator are ignored — Midnight
-  // has no dispatch-coupled hooks to attach.
+  // Deploys the night monolith: mailbox, ISM, and native warp route in one
+  // contract. The multisig ISM config is consumed here, since validators,
+  // threshold, and decimals are constructor args sealed at deploy time. Hook
+  // placeholders from the orchestrator are ignored.
   async create(
     artifact: ArtifactNew<MailboxOnChain>,
   ): Promise<[DeployedRawMailboxArtifact, TxReceipt[]]> {
@@ -119,11 +116,9 @@ class MidnightMailboxWriter
         ],
       });
 
-    // The ISM artifact still carries the pre-deploy placeholder address
-    // (see MidnightMultisigIsmWriter.create), and the core orchestrator
-    // reuses that same object when reporting deployed addresses. Stamp the
-    // real address on it now that it exists: the night contract is its own
-    // ISM.
+    // The ISM artifact still carries its pre-deploy placeholder address, and the
+    // orchestrator reuses that same object when reporting deployed addresses.
+    // The night contract is its own ISM, so stamp the real address on now.
     config.defaultIsm.deployed.address = address;
 
     return [

--- a/typescript/midnight-sdk/src/witnesses/igp-witnesses.ts
+++ b/typescript/midnight-sdk/src/witnesses/igp-witnesses.ts
@@ -1,8 +1,7 @@
-// Permanent off-chain implementation of the gas-payment division: the
-// three-factor numerator exceeds Uint<128>, so it cannot go through
-// Scale.divRemPow10. The circuit binds (q, r) to the true product in Field
-// arithmetic. Mirrors contracts/src/witnesses/igp-witnesses.ts in the
-// hyperlane-midnight repo — keep in sync.
+// The gas-payment division stays off-chain: its three-factor numerator exceeds
+// Uint<128>, so it cannot go through Scale.divRemPow10, and the circuit binds
+// (q, r) to the true product in Field arithmetic instead. Mirrors the contracts
+// repo's own witnesses — keep in sync.
 const TOKEN_EXCHANGE_RATE_SCALE = 10n ** 10n;
 
 export function createIgpWitnesses<PS>(initialPrivateState: PS) {

--- a/typescript/midnight-sdk/src/witnesses/scale-witnesses.ts
+++ b/typescript/midnight-sdk/src/witnesses/scale-witnesses.ts
@@ -1,7 +1,6 @@
-// Permanent off-chain implementation of power-of-10 division (Compact has no
-// integer division); the circuit binds each result in Field arithmetic.
-// Mirrors contracts/src/witnesses/scale-witnesses.ts in the hyperlane-midnight
-// repo — keep in sync.
+// Compact has no integer division, so power-of-10 division stays off-chain and
+// the circuit binds each result in Field arithmetic. Mirrors the contracts
+// repo's own witnesses — keep in sync.
 export function createScaleWitnesses<PS>(initialPrivateState: PS) {
   return {
     divRemPow10Witness(

--- a/typescript/provider-sdk/src/ism.ts
+++ b/typescript/provider-sdk/src/ism.ts
@@ -264,12 +264,10 @@ export interface IRawIsmArtifactManager extends IArtifactManager<
   readIsm(address: string): Promise<DeployedRawIsmArtifact>;
 
   /**
-   * Whether "static" ISM types (multisig, test) are mutable in place on this
-   * protocol. Defaults to false (EVM semantics: static ISMs are immutable and
-   * a config change means a new deployment). Protocols whose multisig ISM
-   * exposes an on-chain rotation entry point (e.g. Midnight's
-   * setValidatorsAndThreshold) return true so config changes route through
-   * the writer's update() instead of a redeploy.
+   * Whether "static" ISM types are mutable in place on this protocol. Defaults
+   * to false, matching EVM, where a config change means a new deployment.
+   * Protocols whose multisig ISM has an on-chain rotation entry point return
+   * true, routing config changes through `update()` instead of a redeploy.
    */
   supportsInPlaceStaticIsmUpdates?(): boolean;
 }
@@ -321,9 +319,8 @@ export function mergeIsmArtifacts(
   currentArtifact: DeployedIsmArtifact | undefined,
   expectedArtifact: ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact,
   options?: {
-    // See IRawIsmArtifactManager.supportsInPlaceStaticIsmUpdates: when true,
-    // a changed static-ISM config keeps the current deployment (routing the
-    // change through the writer's update()) instead of forcing a redeploy.
+    // When true, a changed static-ISM config keeps the current deployment and
+    // routes the change through the writer's `update()`.
     allowInPlaceStaticUpdate?: boolean;
   },
 ): ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact {

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -818,12 +818,10 @@ export function buildAgentConfig(
           ? formatMidnightAddress(addresses[chain])
           : addresses[chain];
 
-    // Midnight agents read chain state via the indexer GraphQL endpoint,
-    // which travels in the metadata's gatewayUrls. The node signer marks
-    // that transaction signing is delegated to the submit-handle subprocess;
-    // its presence is what lets the validator self-announce. toolkitPath
-    // (the subprocess binary) is a host-local path the operator supplies
-    // via additionalConfig or by editing the rendered file.
+    // The indexer GraphQL endpoint travels in the metadata's gatewayUrls. The
+    // node signer marks that signing is delegated to the submitter subprocess,
+    // and its presence is what lets the validator self-announce. `toolkitPath`
+    // is host-local, so the operator supplies it separately.
     const midnightConfig =
       metadata?.protocol === ProtocolType.Midnight
         ? {

--- a/typescript/sdk/src/providers/builders/midnight.ts
+++ b/typescript/sdk/src/providers/builders/midnight.ts
@@ -7,9 +7,8 @@ import { ProviderType } from '../ProviderType.js';
 import type { ProviderBuilderFn } from './types.js';
 
 /**
- * Midnight has no JSON-RPC interface; the read provider runs contract
- * circuits locally against state fetched from the chain's GraphQL indexer
- * (gatewayUrls). Construction never dials the network.
+ * Midnight has no JSON-RPC interface: the read provider runs contract circuits
+ * locally against state fetched from the GraphQL indexer in `gatewayUrls`.
  */
 export const defaultMidnightProviderBuilder: ProviderBuilderFn<
   MidnightProvider

--- a/typescript/utils/src/addresses.ts
+++ b/typescript/utils/src/addresses.ts
@@ -131,9 +131,9 @@ export function getAddressProtocolType(address: Address) {
   } else if (isAddressRadix(address)) {
     return ProtocolType.Radix;
   } else if (isAddressMidnight(address)) {
-    // Unreachable for 0x-prefixed input: CosmosNative shares the 32-byte hex
-    // shape and is checked first (Starknet has the same shadowing). Explicit
-    // protocol dispatch is the supported path for Midnight addresses.
+    // Unreachable for 0x-prefixed input, since CosmosNative shares the 32-byte
+    // hex shape and is checked first. Midnight addresses are meant to be
+    // dispatched by explicit protocol instead.
     return ProtocolType.Midnight;
   } else {
     return undefined;

--- a/typescript/widgets/src/walletIntegrations/midnight.ts
+++ b/typescript/widgets/src/walletIntegrations/midnight.ts
@@ -14,10 +14,9 @@ import type {
 } from './types.js';
 
 /**
- * Midnight has no browser wallet integration yet (transactions require a
- * proof-server pipeline that browser wallets do not provide). These hooks
- * satisfy the per-protocol wallet maps with inert values; any attempt to
- * actually transact fails loudly.
+ * Midnight has no browser wallet integration yet: transactions need a
+ * proof-server pipeline browser wallets do not provide. These hooks fill the
+ * per-protocol wallet maps with inert values and throw if actually used.
  */
 
 const NO_WALLET_MSG =


### PR DESCRIPTION
Comment-only pass over the Midnight work, in two rounds: the first rewrote the
overlong comments, the second deleted the ones that should not have existed at
all. Net ~900 lines of comment removed.

## What went

- **Docs that only echoed the item name.** `toolkit.rs` alone had about a
  hundred: the same `/// Operation discriminator` / `/// Indexer GraphQL
  endpoint (HTTP)` block repeated across six near-identical request structs.
  Nothing in that module is reachable outside the crate, so none of it was
  required by `missing_docs` — confirmed by clippy after removal.
- **Module and crate headers written as essays.** The Rust siblings
  (`hyperlane-cosmos`, `hyperlane-aleo`, `hyperlane-sealevel`) all open with a
  single line, so these do too, keeping only what is not visible from the code:
  the feature gate, the off-chain merkle tree, the `Bytes<N>` trailing-zero
  trim. `merkle_tree_hook.rs` went 36 header lines to 10, `metadata_tests.rs`
  31 to 12, `state_decode.rs` 22 to 7.
- **Comments restating the assertion beneath them.** A line reading "a shared
  prefix does not match" sitting above an assert that a shared prefix does not
  match tells nobody anything.
- **Cross-chain trivia.** Whether a choice matches EVM, Aleo, or Sealevel is
  interesting while writing the code and useless while reading it. It stays
  only where it grounds a whole design (the off-chain merkle tree).
- **Every `#N` issue reference**, including two in runtime strings: a `todo!()`
  message and an error message a user could actually see.
- **Match-arm narration.** The Midnight arms in `chains.rs`, `cursors/mod.rs`
  and `chain.rs` each had a comment describing the line below it, where every
  surrounding arm has none. One was also **stale** — it still described reading
  `count`/`current_root` from an on-chain merkle tree that was removed. The
  `state_decode.rs` header was stale too: it listed field positions (`[0, 8]`,
  `[0, 9]`) that contradicted the actual constants directly below it.
- **Version detail that dates fast** (compact-js, wallet-sdk, midnight-js, node)
  where the behaviour is the point. The reason the chunked deploy is hand-built
  at the ledger level is still there; the exact version that forced it is not.
- **Stale claims.** The midnight-sdk README no longer says "under
  construction", and the `PARTIAL_SUCCESS` note no longer says segment
  attribution is still being verified — that was confirmed safe.
- **`core-config.yaml`** trimmed from a 14-line preamble to 5, matching the
  other example configs.

## Three changes that are not comments

Flagging these since everything else is comment-only:

1. Deleted `announce_and_read_back_on_devnet` in `validator_announce.rs`. It was
   `#[ignore]` plus `unimplemented!()` and a four-step plan in a comment — it
   never ran and never asserted anything. Say the word if you'd rather keep the
   placeholder.
2. Renamed `tx_status_filter_is_the_single_decision_point` to
   `tx_status_filter_excludes_only_failures`, so the name says what it asserts.
3. Dropped an unnecessary `mut` in `mailbox.rs`.

## Verification

- `cargo test -p hyperlane-midnight` — 84 passed, 3 ignored
- `cargo clippy -p hyperlane-midnight --all-targets` — no `missing_docs`, no new
  warnings (one pre-existing `is_multiple_of` suggestion, untouched by this PR)
- `cargo check -p hyperlane-base -p relayer -p lander -p validator --features midnight` — clean
- `cargo fmt --all --check` — clean
- `tsc --noEmit` on sdk and cli; builds green for midnight-sdk, provider-sdk,
  deploy-sdk
- `oxlint` clean on every touched TS file
- Diffed every changed file with comment lines stripped, against both the base
  and the first round: the only non-comment changes are the three above.
