### PR TITLE
docs(midnight): bring the SDK readme up to the AltVM template

### DIFF
--- a/.changeset/midnight-sdk-readme.md
+++ b/.changeset/midnight-sdk-readme.md
@@ -1,0 +1,12 @@
+---
+'@hyperlane-xyz/midnight-sdk': patch
+'@hyperlane-xyz/cli': patch
+---
+
+Documented the Midnight SDK to match the other AltVM SDK packages: install, a
+usage example, and the environment variables it reads. Records the two things
+that differ from its siblings — chain state is read through the indexer via
+`gatewayUrls` rather than from the node, and `warp deploy` does not create the
+Midnight side of a route because the token logic lives inside the core
+contract. Adds `midnight` to the CLI's supported-protocol lists, which omitted
+a protocol the code already accepts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ pnpm test          # Run relevant tests
 pnpm changeset     # Add changeset if modifying published packages
 
 # Rust (CI-compatible commands)
-cd rust/main && cargo clippy --features aleo,integration_test -- -D warnings
-cd rust/main && cargo test --all-targets --features aleo,integration_test
+cd rust/main && cargo clippy --features aleo,midnight,integration_test -- -D warnings
+cd rust/main && cargo test --all-targets --features aleo,midnight,integration_test
 cd rust/main && cargo fmt
 ```
 
@@ -296,6 +296,7 @@ See `docs/2025-11-20-multi-vm-migration.md` for full migration guide.
 | `hyperlane-aleo`     | Aleo          |
 | `hyperlane-radix`    | Radix         |
 | `hyperlane-starknet` | Starknet      |
+| `hyperlane-midnight` | Midnight      |
 
 **Core Crates**: `hyperlane-core` (traits, message types), `hyperlane-base` (shared agent utilities)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,8 @@ pnpm test          # Run relevant tests
 pnpm changeset     # Add changeset if modifying published packages
 
 # Rust (CI-compatible commands)
-cd rust/main && cargo clippy --features aleo,integration_test -- -D warnings
-cd rust/main && cargo test --all-targets --features aleo,integration_test
+cd rust/main && cargo clippy --features aleo,midnight,integration_test -- -D warnings
+cd rust/main && cargo test --all-targets --features aleo,midnight,integration_test
 cd rust/main && cargo fmt
 ```
 
@@ -298,6 +298,7 @@ See `docs/2025-11-20-multi-vm-migration.md` for full migration guide.
 | `hyperlane-aleo`     | Aleo          |
 | `hyperlane-radix`    | Radix         |
 | `hyperlane-starknet` | Starknet      |
+| `hyperlane-midnight` | Midnight      |
 
 **Core Crates**: `hyperlane-core` (traits, message types), `hyperlane-base` (shared agent utilities)
 

--- a/typescript/cli/README.md
+++ b/typescript/cli/README.md
@@ -87,7 +87,7 @@ hyperlane address to-bytes32 --address <address> [--protocol <protocol>]
 **Flags:**
 
 - `--address, -a` - The address to convert (required)
-- `--protocol, -p` (optional) - Protocol type: ethereum, sealevel, cosmos, cosmosnative, starknet, radix, aleo, tron. Auto-detected if not specified.
+- `--protocol, -p` (optional) - Protocol type: ethereum, sealevel, cosmos, cosmosnative, starknet, radix, aleo, tron, midnight. Auto-detected if not specified.
 
 **Examples:**
 
@@ -148,3 +148,4 @@ hyperlane address from-bytes32 -b 0x00000000000000000000000071b24bf8489d5785c850
 - `radix` - Radix DLT
 - `aleo` - Aleo
 - `tron` - Tron
+- `midnight` - Midnight

--- a/typescript/midnight-sdk/README.md
+++ b/typescript/midnight-sdk/README.md
@@ -1,9 +1,89 @@
 # Hyperlane Midnight SDK
 
-Implements the `ProtocolProvider` interface from `@hyperlane-xyz/provider-sdk`
-for the Midnight network, making Midnight a first-class protocol in the
-Hyperlane CLI (`core`/`warp` `read`, `check`, `deploy`, `apply`, `send`).
+The Hyperlane Midnight SDK is a fully typed TypeScript SDK for the [Midnight Implementation](https://github.com/equilibriumco/hyperlane-midnight).
+It can be used as a standalone SDK for frontend or in backend applications which want to connect to a Midnight chain which has the Hyperlane contracts deployed.
 
-Midnight chain metadata carries two endpoint sets: `rpcUrls` point at the
-node, while `gatewayUrls` carry the indexer GraphQL endpoint, which is the
-read path for all chain state.
+## Install
+
+```bash
+# Install with NPM
+npm install @hyperlane-xyz/midnight-sdk
+
+# Or with pnpm
+pnpm add @hyperlane-xyz/midnight-sdk
+```
+
+## Usage
+
+```ts
+import { MidnightProvider, MidnightSigner } from '@hyperlane-xyz/midnight-sdk';
+import {
+  ChainMetadataForAltVM,
+  ProtocolType,
+} from '@hyperlane-xyz/provider-sdk';
+
+const metadata: ChainMetadataForAltVM = {
+  name: 'midnight',
+  protocol: ProtocolType.Midnight,
+  chainId: 1234,
+  domainId: 1234,
+  // rpcUrls point at the node: this is the submit path.
+  rpcUrls: [{ http: 'http://localhost:9944' }],
+  // gatewayUrls carry the indexer GraphQL endpoint: this is the read path for
+  // all chain state. Both are required.
+  gatewayUrls: [{ http: 'http://localhost:8088/api/v3/graphql' }],
+  // Required. Signing throws without it.
+  midnightNetworkId: 'undeployed',
+};
+
+const signer = await MidnightSigner.connectWithSigner(metadata, SEED);
+
+const mailbox = await signer.getMailbox({ mailboxAddress });
+
+// performing queries without signer
+const provider = await MidnightProvider.connect(metadata);
+
+const mailbox = await provider.getMailbox({ mailboxAddress });
+```
+
+Two things differ from the other AltVM SDKs and are worth knowing first:
+
+- **State reads go through the indexer, not the node.** `gatewayUrls` is not
+  optional; a chain entry carrying only `rpcUrls` cannot answer a read.
+- **`warp deploy` does not create the Midnight side of a route.** Midnight has
+  no cross-contract calls, so the token logic lives inside the core contract
+  and the route is created by `core deploy`. A warp deploy targets the
+  counterpart chain and references the Midnight end as a `foreignDeployment`.
+
+## Environment variables
+
+Submitting a transaction on Midnight means generating a zero-knowledge proof
+locally, so this SDK needs a proof server and the compiled contract artifacts
+on disk.
+
+- **HYPERLANE_MIDNIGHT_CONTRACTS=\<path>**: the compiled contract tree from
+  [hyperlane-midnight](https://github.com/equilibriumco/hyperlane-midnight)
+  (`contracts/src/managed`). Export it before **building** this package, not
+  only before using it: the build copies the artifacts in, and without it
+  copies from whatever sibling checkout it happens to find. The packaged
+  fallback carries verifier keys only, so proving fails at run time rather than
+  at build time.
+- **MIDNIGHT_PROOF_SERVER_URL=\<url>**: proof server to prove against, default
+  local. There is no public proof server.
+- **MIDNIGHT_NETWORK=devnet/stagenet**: selects default endpoints. Unset on a
+  stagenet host means every endpoint quietly points at localhost.
+- **MIDNIGHT_STATE_DIR=\<path>**: holds the ownership secret and private state.
+  Losing it forfeits contract ownership and the ability to update circuits, so
+  back it up after a deploy.
+- **MIDNIGHT_STATE_PASSWORD=\<password>**: encrypts that state. There is no
+  rotation path, so set it before first use.
+- **MIDNIGHT_SUBMIT_TIMEOUT_SECS=\<seconds>**: submit timeout. The default is
+  well below the time an inbound delivery proof takes, so raise it when running
+  agents.
+
+## Setup
+
+Node 18 or newer is required.
+
+Building this package requires the compiled Compact artifacts described above;
+compile them in the contracts repository first.


### PR DESCRIPTION
The `midnight-sdk` readme was nine lines. Every sibling AltVM SDK readme is 43-83, and they all follow one template: identity sentence, `## Install`, `## Usage` with a runnable snippet, `## Setup`. This brings ours onto it.

## It also said something wrong

The old readme advertised `warp` `deploy` as working. It does not: Midnight has no cross-contract calls, so the token logic lives inside the core contract and the route is created by `core deploy`. A warp deploy targets the counterpart chain and references the Midnight end as a `foreignDeployment`. The implementation repo said so, and the two documents disagreed.

## What is new

Beyond the template, an `## Environment variables` section — `aleo-sdk` is the only sibling with one, and this package needs it more, because proving happens locally and needs both a proof server and the compiled Compact artifacts on disk. Two items in it were documented nowhere at all:

- **`midnightNetworkId`** is mandatory. Signing throws without it. It is in no schema, so nothing validates its presence for you.
- **`HYPERLANE_MIDNIGHT_CONTRACTS`** must be exported before *building* this package, not just before using it. Unset, the build copies artifacts from whatever sibling checkout it finds, and the packaged fallback carries verifier keys only — so proving fails at run time rather than at build time.

Also records that `gatewayUrls` is the read path for all chain state, which is the difference most likely to bite someone wiring a chain entry for the first time.

## Beyond the SDK readme

- `midnight` added to the CLI readme's two supported-protocol lists. Both omitted a protocol the code already accepts, so `hyperlane address to-bytes32 -p midnight` works today but is undocumented.
- The pre-commit Rust commands in `AGENTS.md` and `CLAUDE.md` are corrected to include the `midnight` feature. CI already runs them that way; as written, nothing behind that feature flag was ever compiled locally, so a contributor could not reproduce CI.
- `hyperlane-midnight` added to the chain-crate table.

Changeset included.